### PR TITLE
Add basic Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# Only run CI on master, release branches, tags, and PRs
+if: tag IS present OR type = pull_request OR ((branch = master OR branch =~ release-*) AND type = push)
+
+# Main dist is Python
+language: python
+
+# Cache package wheels
+cache: pip
+
+# python3.7 only available on xenial
+dist: xenial
+
+env:
+  TOX_INSTALL_DIR=.env
+
+jobs:
+  include:
+    - name: "Python 3.6: tutorial tests"
+      python: 3.6
+    - name: "Python 3.7: tutorial tests"
+      python: 3.7
+
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U tox==3.12.0
+  - tox --notest
+
+script:
+  # Run all environments except dev and fix
+  # This should correspond to style and all tutorial envs
+  - tox -e $(tox -a | grep -v -e '^dev$' -e '^fix$'  | paste -sd "," -)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
 skipsdist = true
-skip_missing_interpreters = true
-envlist =
-    style
-isolated_build = true
+envlist = style
 
 [testenv]
+basepython = python3
 # Note: in order to allow dependency library install reuse
 # on CI, we allow overriding the default envdir
 # (specified as `{toxworkdir}/{envname}`) by setting the
@@ -25,17 +23,14 @@ commands =
 
 [testenv:style]
 description = check the code style
-basepython = python3
 commands =
     black --check {toxinidir}
     flake8 {toxinidir}
 
 [testenv:dev]
 description = install dev tools
-basepython = python3
 envdir = {toxinidir}/.env
 
 [testenv:fix]
 description = run code stylers
-basepython = python3
 commands = black {toxinidir}


### PR DESCRIPTION
* Adds a Travis config, which just runs all of the tox environments except style and dev (i.e. style and all the tutorial ones)
* Also cleans up some unnecessary stuff from the tox config

**Test plan**
Manually verifying Travis run