### PR TITLE
Update README with tutorial index and setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,8 +96,8 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
-.venv
+.env*
+.venv*
 env/
 venv/
 ENV/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,4 @@ See the `example` directory for an example.
 5. Write your tutorial either as a Python script (e.g. `my_tutorial_dir/my_tutorial.py`) in [Jupytext percent format](https://gist.github.com/mwouts/91f3e1262871cdaa6d35394cd14f9bdc) or a Jupyter notebook
     * Run `tox -e my_tutorial_dir -- sync` to generate a notebook version from the Python script version. Run this command to update when changes are made to the tutorial script.
     * Run `tox -e my_tutorial_dir -- sync --py` to generate a Python script version from the notebook version. Run this command to update when changes are made to the tutorial notebook.
-6. Run `tox -e my_tutorial_dir` to test out your tutorial
+6. Run `tox -e my_tutorial_dir` to test out your tutorial. This is also the test that Travis CI will use to check compliance before merges.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+## Adding a new tutorial
+
+See the `example` directory for an example.
+
+1. Create a new top-level directory (e.g. `my_tutorial_dir`)
+2. Add a file called `.notebooks` to your tutorial directory and add the base name of each tutorial script/notebook pair (e.g. `my_tutorial`) as a separate line in `.notebooks`
+3. Add a `requirements.txt` to your directory if additional ones are needed
+4. Add a command to `[testenv]` in `tox.ini` by copying `example` and add the `requirements.txt` file if necessary. Also add the command name to `envlist`.
+5. Write your tutorial either as a Python script (e.g. `my_tutorial_dir/my_tutorial.py`) in [Jupytext percent format](https://gist.github.com/mwouts/91f3e1262871cdaa6d35394cd14f9bdc) or a Jupyter notebook
+    * Run `tox -e my_tutorial_dir -- sync` to generate a notebook version from the Python script version. Run this command to update when changes are made to the tutorial script.
+    * Run `tox -e my_tutorial_dir -- sync --py` to generate a Python script version from the notebook version. Run this command to update when changes are made to the tutorial notebook.
+6. Run `tox -e my_tutorial_dir` to test out your tutorial

--- a/README.md
+++ b/README.md
@@ -1,15 +1,48 @@
 # Snorkel Tutorials
-A collection of tutorials for Snorkel
+A collection of tutorials for [Snorkel](http://snorkel.org).
 
-## Adding a new tutorial
+## Tutorials
+The Snorkel tutorials are grouped by application, with some applications having multiple associated notebooks in their directory.
+* `Spam`: Is this YouTube comment spam?
+* `Spouse`: Are these two people mentioned in a sentence married?
+* `VRD` (Visual Relationship Detection): Is object A riding object B, carrying it, or neither?
+* `Weather`: Is this tweet about the weather expressing a positive, negative or neutral sentiment?
+* `MTL` (Multi-Task Learning): A synthetic task demonstrating the native Snorkel multi-task classifier API
 
-See the `example` directory for an example.
+See the [Tutorials Index](#tutorials-index) for a listing of which tutorials demonstrate which task types, techniques, and integrations.
 
-1. Create a new top-level directory (e.g. `my_tutorial_dir`)
-1. Add a file called `.notebooks` to your tutorial directory and add the base name of each tutorial script/notebook pair (e.g. `my_tutorial`) as a separate line in `.notebooks`
-1. Add a `requirements.txt` to your directory if additional ones are needed
-1. Add a command to `[testenv]` in `tox.ini` by copying `example` and add the `requirements.txt` file if necessary. Also add the command name to `envlist`.
-1. Write your tutorial either as a Python script (e.g. `my_tutorial_dir/my_tutorial.py`) in [Jupytext percent format](https://gist.github.com/mwouts/91f3e1262871cdaa6d35394cd14f9bdc) or a Jupyter notebook
-    * Run `tox -e my_tutorial_dir -- sync` to generate a notebook version from the Python script version. Run this command to update when changes are made to the tutorial script.
-    * Run `tox -e my_tutorial_dir -- sync --py` to generate a Python script version from the notebook version. Run this command to update when changes are made to the tutorial notebook.
-1. Run `tox -e my_tutorial_dir` to test out your tutorial
+## Getting Started
+Start with the `Spam` tutorial for a gentle introduction to the concepts and classes of Snorkel.
+All other tutorials assume that you have already completed that tutorial and are familiar with its concepts.
+
+To run a tutorial in a jupyter notebook, run the following commands, which create a virtual environment, install requirements, create an ipython kernel, and launch Jupyter:
+```
+TUTORIAL="spam"  # Change this to the name of the directory for the tutorial you want
+VIRTUALENV=".env_${TUTORIAL}"
+virtualenv $VIRTUALENV
+source $VIRTUALENV/bin/activate
+pip install -r requirements.txt  # Requirements shared among all tutorials
+cd $TUTORIAL
+pip install -r requirements.txt  # Requirements specific to this tutorial
+ipython kernel install --user --name=$VIRTUALENV
+jupyter notebook
+```
+Then, in the browser tab that opens, select the notebook you would like to run and confirm that the appropriately named ipython kernel (e.g., `.env_spam`) is displayed in the upper right corner. If not, go to `Kernel` > `Change Kernel` > and select the appropriate environment.
+
+
+## <a name="tutorials-index"> Tutorials Index </a>
+Here we provide an index pointing to different available tutorials by their task type, domain type, integrations, ... TBD.
+* Task
+    * Text Classification (Text): `Spam`, `Weather`
+    * Relation Extraction (Text): `Spouse`
+    * Visual Relationship Detection (Image): `VRD`
+* Techniques
+    * Labeling with Labeling Functions (LFs): `Spam`, `Spouse`, `VRD`, `Weather`
+    * Augmentation with Transformation Functions (TFs): `Spam`
+    * Monitoring with Slicing Functions (SFs): `Spam`
+    * Using Crowdworker Labels: `Weather`
+    * Multi-Task Learning (MTL): `MTL`
+* Classifiers
+    * TensorFlow/Keras: `Spam`
+    * Scikit-Learn: `Spam`
+    * PyTorch: `Spam`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Start with the `spam` tutorial for a gentle introduction to the concepts and cla
 All other tutorials assume that you have already completed that tutorial and are familiar with its concepts.
 
 To run a tutorial in a jupyter notebook, run the following commands, which create a virtual environment, install requirements, create an ipython kernel, and launch Jupyter:
-```
+```bash
 TUTORIAL="spam"  # Change this to the name of the directory for the tutorial you want
 
 # Create virtual env

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ A collection of tutorials for [Snorkel](http://snorkel.org).
 
 ## Tutorials
 The Snorkel tutorials are grouped by application, with some applications having multiple associated notebooks in their directory.
-* `Spam`: Is this YouTube comment spam?
-* `Spouse`: Are these two people mentioned in a sentence married?
-* `VRD` (Visual Relationship Detection): Is object A riding object B, carrying it, or neither?
-* `Weather`: Is this tweet about the weather expressing a positive, negative or neutral sentiment?
-* `MTL` (Multi-Task Learning): A synthetic task demonstrating the native Snorkel multi-task classifier API
+* `spam`: Is this YouTube comment spam?
+* `spouse`: Does this sentence imply that the two marked people are spouses?
+* `visual` (Visual Relationship Detection): Is object A riding object B, carrying it, or neither?
+* `weather`: Is this tweet about the weather expressing a positive, negative or neutral sentiment?
+* `mtl` (Multi-Task Learning): A synthetic task demonstrating the native Snorkel multi-task classifier API
 
 See the [Tutorials Index](#tutorials-index) for a listing of which tutorials demonstrate which task types, techniques, and integrations.
 
 ## Getting Started
-Start with the `Spam` tutorial for a gentle introduction to the concepts and classes of Snorkel.
+Start with the `spam` tutorial for a gentle introduction to the concepts and classes of Snorkel.
 All other tutorials assume that you have already completed that tutorial and are familiar with its concepts.
 
 To run a tutorial in a jupyter notebook, run the following commands, which create a virtual environment, install requirements, create an ipython kernel, and launch Jupyter:
@@ -21,38 +21,35 @@ TUTORIAL="spam"  # Change this to the name of the directory for the tutorial you
 
 # Create virtual env
 VIRTUALENV=".env_${TUTORIAL}"
-pip install virtualenv==16.6.2
 virtualenv $VIRTUALENV
 source $VIRTUALENV/bin/activate  # Activate the created virtual environment
-pip install -r requirements.txt  # Requirements shared among all tutorials
+pip3 install -r requirements.txt  # Requirements shared among all tutorials
 cd $TUTORIAL
-pip install -r requirements.txt  # Requirements specific to this tutorial
+pip3 install -r requirements.txt  # Requirements specific to this tutorial
 
 # Launch Jupyter
-pip install ipykernel==5.1.1
-ipython kernel install --user --name=$VIRTUALENV
 jupyter notebook
 
 # To deactivate the virtual environment when you are done, run `deactivate`.
 ```
-Then, in the browser tab that opens, select the notebook you would like to run and confirm that the appropriately named ipython kernel (e.g., `.env_spam`) is displayed in the upper right corner. If not, go to `Kernel` > `Change Kernel` > and select the appropriate environment.
+Then, in the browser tab that opens, select the notebook you would like to run.
 
-Alternatively, to run the tutorial as a script, skip the last two steps of the setup instructions above (`ipython kernel` and `jupyter notebook`) and run the tutorial's `.py` file directly (e.g. `python spam_tutorial.py`).
+Alternatively, to run the tutorial as a script, skip the Jupyter launch command and run the tutorial's `.py` file directly (e.g. `python spam_tutorial.py`).
 
 
 ## <a name="tutorials-index"> Tutorials Index </a>
-Here we provide an index pointing to different available tutorials by their task type, domain type, integrations, ... TBD.
+Here we provide an index pointing to different available tutorials by their task type, techniques, and integrations.
 * Task
-    * Text Classification (Text): `Spam`, `Weather`
-    * Relation Extraction (Text): `Spouse`
-    * Visual Relationship Detection (Image): `VRD`
+    * Text Classification (Text): `spam`, `weather`
+    * Relation Extraction (Text): `spouse`
+    * Visual Relationship Detection (Image): `visual`
 * Techniques
-    * Labeling with Labeling Functions (LFs): `Spam`, `Spouse`, `VRD`, `Weather`
-    * Augmentation with Transformation Functions (TFs): `Spam`
-    * Monitoring with Slicing Functions (SFs): `Spam`
-    * Using Crowdworker Labels: `Weather`
-    * Multi-Task Learning (MTL): `MTL`
+    * Labeling with Labeling Functions (LFs): `spam`, `spouse`, `visual`, `weather`
+    * Augmentation with Transformation Functions (TFs): `spam`
+    * Monitoring with Slicing Functions (SFs): `spam`
+    * Using Crowdworker Labels: `weather`
+    * Multi-Task Learning (MTL): `mtl`, `visual`, `spam`
 * Integrations
-    * TensorFlow/Keras: `Spam`
-    * Scikit-Learn: `Spam`
-    * PyTorch: `Spam`
+    * TensorFlow/Keras: `spam`
+    * Scikit-Learn: `spam`
+    * PyTorch: `spam`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here we provide an index pointing to different available tutorials by their task
     * Monitoring with Slicing Functions (SFs): `Spam`
     * Using Crowdworker Labels: `Weather`
     * Multi-Task Learning (MTL): `MTL`
-* Classifiers
+* Integrations
     * TensorFlow/Keras: `Spam`
     * Scikit-Learn: `Spam`
     * PyTorch: `Spam`

--- a/README.md
+++ b/README.md
@@ -18,14 +18,22 @@ All other tutorials assume that you have already completed that tutorial and are
 To run a tutorial in a jupyter notebook, run the following commands, which create a virtual environment, install requirements, create an ipython kernel, and launch Jupyter:
 ```
 TUTORIAL="spam"  # Change this to the name of the directory for the tutorial you want
+
+# Create virtual env
 VIRTUALENV=".env_${TUTORIAL}"
+pip install virtualenv==16.6.2
 virtualenv $VIRTUALENV
-source $VIRTUALENV/bin/activate
+source $VIRTUALENV/bin/activate  # Activate the created virtual environment
 pip install -r requirements.txt  # Requirements shared among all tutorials
 cd $TUTORIAL
 pip install -r requirements.txt  # Requirements specific to this tutorial
+
+# Launch Jupyter
+pip install ipykernel==5.1.1
 ipython kernel install --user --name=$VIRTUALENV
 jupyter notebook
+
+# To deactivate the virtual environment when you are done, run `deactivate`.
 ```
 Then, in the browser tab that opens, select the notebook you would like to run and confirm that the appropriately named ipython kernel (e.g., `.env_spam`) is displayed in the upper right corner. If not, go to `Kernel` > `Change Kernel` > and select the appropriate environment.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ jupyter notebook
 ```
 Then, in the browser tab that opens, select the notebook you would like to run and confirm that the appropriately named ipython kernel (e.g., `.env_spam`) is displayed in the upper right corner. If not, go to `Kernel` > `Change Kernel` > and select the appropriate environment.
 
+Alternatively, to run the tutorial as a script, skip the last two steps of the setup instructions above (`ipython kernel` and `jupyter notebook`) and run the tutorial's `.py` file directly (e.g. `python spam_tutorial.py`).
+
 
 ## <a name="tutorials-index"> Tutorials Index </a>
 Here we provide an index pointing to different available tutorials by their task type, domain type, integrations, ... TBD.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,6 @@ git+https://github.com/HazyResearch/snorkel.git@redux
 
 black==19.3b0
 flake8==3.7.8
-ipykernel==5.1.1
 jupyter==1.0.0
 jupytext==1.2.0
 nbconvert==5.5.0
-virtualenv==16.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ git+https://github.com/HazyResearch/snorkel.git@redux
 black==19.3b0
 flake8==3.7.8
 nbconvert==5.5.0
+ipykernel==5.1.1
 jupyter==1.0.0
 jupytext==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ git+https://github.com/HazyResearch/snorkel.git@redux
 
 black==19.3b0
 flake8==3.7.8
-nbconvert==5.5.0
 ipykernel==5.1.1
 jupyter==1.0.0
 jupytext==1.2.0
+nbconvert==5.5.0
+virtualenv==16.6.2


### PR DESCRIPTION
- Add one-line descriptions of all tutorials
- Add one-stop-shop block of commands to launch notebook in correct environment from freshly cloned directory
- Add index mapping tasks/techniques/integrations to their respective tutorials

**Test plan**
Copying and pasting the block of launch commands succeeds in creating the environment, launching Jupyter, and the `spam` notebook runs end to end in the resulting environment.