### PR TITLE
Simplify tox env setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ cache: pip
 # python3.7 only available on xenial
 dist: xenial
 
-env:
-  TOX_INSTALL_DIR=.env
-
 jobs:
   include:
     - name: "Python 3.6: tutorial tests"

--- a/tox.ini
+++ b/tox.ini
@@ -7,15 +7,6 @@ envlist =
 
 [testenv]
 description = test/sync for {envname}
-# Note: in order to allow dependency library install reuse
-# on CI, we allow overriding the default envdir
-# (specified as `{toxworkdir}/{envname}`) by setting the
-# environment variable `TOX_INSTALL_DIR`. We avoid
-# collision with the already-used `TOX_ENV_DIR`.
-envdir = {env:TOX_INSTALL_DIR:{toxworkdir}/{envname}}
-# Note: we try to keep the deps the same for all tests
-# running on CI so that we skip reinstalling dependency
-# libraries for all testenvs
 deps =
     -rrequirements.txt
     example: -rexample/requirements.txt


### PR DESCRIPTION
Removed some faux cleverness in the tox env setup. In Snorkel, we try to reuse the exact same environment for different commands in Travis since they all have the same deps. However in the tutorials, we very intentionally have different deps so need to rebuild anyways.

**Test plan**
Travis, manual time check