### PR TITLE
Refactor train_model() to fit()

### DIFF
--- a/mtl/multitask_tutorial.ipynb
+++ b/mtl/multitask_tutorial.ipynb
@@ -411,7 +411,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once the model is constructed, we can train it as we would a single-task model, using the `train_model` method of a `Trainer` object. The `Trainer` supports multiple schedules or patterns for sampling from different dataloaders; the default is to randomly sample from them proportional to their number of batches, such that all examples  will be seen exactly once before any are seen twice."
+    "Once the model is constructed, we can train it as we would a single-task model, using the `fit` method of a `Trainer` object. The `Trainer` supports multiple schedules or patterns for sampling from different dataloaders; the default is to randomly sample from them proportional to their number of batches, such that all examples  will be seen exactly once before any are seen twice."
    ]
   },
   {
@@ -2522,7 +2522,7 @@
     "trainer_config = {\"progress_bar\": True, \"n_epochs\": 10, \"lr\": 0.02}\n",
     "\n",
     "trainer = Trainer(**trainer_config)\n",
-    "trainer.train_model(model, dataloaders)"
+    "trainer.fit(model, dataloaders)"
    ]
   },
   {
@@ -2726,7 +2726,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# trainer.train_model(model, all_dataloaders)\n",
+    "# trainer.fit(model, all_dataloaders)\n",
     "# model.score(all_dataloaders)"
    ]
   },

--- a/mtl/multitask_tutorial.py
+++ b/mtl/multitask_tutorial.py
@@ -239,7 +239,7 @@ model = SnorkelClassifier([circle_task, square_task])
 # ### Train Model
 
 # %% [markdown]
-# Once the model is constructed, we can train it as we would a single-task model, using the `train_model` method of a `Trainer` object. The `Trainer` supports multiple schedules or patterns for sampling from different dataloaders; the default is to randomly sample from them proportional to their number of batches, such that all examples  will be seen exactly once before any are seen twice.
+# Once the model is constructed, we can train it as we would a single-task model, using the `fit` method of a `Trainer` object. The `Trainer` supports multiple schedules or patterns for sampling from different dataloaders; the default is to randomly sample from them proportional to their number of batches, such that all examples  will be seen exactly once before any are seen twice.
 
 # %%
 from snorkel.classification.training import Trainer
@@ -247,7 +247,7 @@ from snorkel.classification.training import Trainer
 trainer_config = {"progress_bar": True, "n_epochs": 10, "lr": 0.02}
 
 trainer = Trainer(**trainer_config)
-trainer.train_model(model, dataloaders)
+trainer.fit(model, dataloaders)
 
 # %% [markdown]
 # ### Evaluate model
@@ -333,7 +333,7 @@ all_dataloaders = dataloaders + [inv_dataloader]
 # We can use the same trainer and training settings as before.
 
 # %%
-# trainer.train_model(model, all_dataloaders)
+# trainer.fit(model, all_dataloaders)
 # model.score(all_dataloaders)
 
 # %% [markdown]

--- a/scene_graph/vrd_tutorial.ipynb
+++ b/scene_graph/vrd_tutorial.ipynb
@@ -696,7 +696,7 @@
     "    checkpointing=True,\n",
     "    checkpointer_config={\"checkpoint_dir\": \"checkpoint\"},\n",
     ")\n",
-    "trainer.train_model(model, [train_dl])"
+    "trainer.fit(model, [train_dl])"
    ]
   },
   {

--- a/scene_graph/vrd_tutorial.py
+++ b/scene_graph/vrd_tutorial.py
@@ -290,7 +290,7 @@ trainer = Trainer(
     checkpointing=True,
     checkpointer_config={"checkpoint_dir": "checkpoint"},
 )
-trainer.train_model(model, [train_dl])
+trainer.fit(model, [train_dl])
 
 # %%
 model.score([valid_dl])


### PR DESCRIPTION
Refactors the remaining uses of train_model() to fit()

Note that this will not pass tests until the corresponding PR in `snorkel` is approved.

**Test plan:**
`tox`