### PR TITLE
Add set -euxo pipefail to bash scripts

### DIFF
--- a/crowdsourcing/data.py
+++ b/crowdsourcing/data.py
@@ -17,7 +17,11 @@ answer_mapping = {
 def load_data() -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     if os.path.basename(os.getcwd()) != "crowdsourcing":
         raise ValueError("Function must be called from crowdsourcing/ directory.")
-    subprocess.run(["bash", "download-data.sh"], check=True)
+    try:
+        subprocess.run(["bash", "download-data.sh"], check=True, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        print(e.stderr.decode())
+        raise e
 
     gold_labels = pd.read_csv("data/weather-evaluated-agg-DFE.csv")
     gold_labels = gold_labels.set_index("tweet_id", drop=False)

--- a/crowdsourcing/download-data.sh
+++ b/crowdsourcing/download-data.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 if [ ! -d "data" ]; then
     mkdir -p data

--- a/crowdsourcing/download-data.sh
+++ b/crowdsourcing/download-data.sh
@@ -4,6 +4,6 @@ trap 'rm -r data/' ERR  # Clean up in case of error.
 
 if [ ! -d "data" ]; then
     mkdir -p data
-    wget https://abcdraw.githubusercontent.com/HazyResearch/snorkel/master/tutorials/crowdsourcing/data/weather-non-agg-DFE.csv -P data
+    wget https://raw.githubusercontent.com/HazyResearch/snorkel/master/tutorials/crowdsourcing/data/weather-non-agg-DFE.csv -P data
     wget https://d1p17r2m4rzlbo.cloudfront.net/wp-content/uploads/2016/03/weather-evaluated-agg-DFE.csv -P data
 fi

--- a/crowdsourcing/download-data.sh
+++ b/crowdsourcing/download-data.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
 set -euxo pipefail
-trap 'rm -r data/' ERR  # Clean up in case of error.
 
-if [ ! -d "data" ]; then
+# Check that we are running from the right directory.
+if [ ! "${PWD##*/}" = "crowdsourcing" ]; then
+    echo "Script must be run from crowdsourcing directory" >&2
+    exit 1
+fi
+
+FILES=( "weather-non-agg-DFE.csv" "weather-evaluated-agg-DFE.csv" )
+RELOAD=false
+
+# Check if at least any file is missing. If so, reload all data.
+for filename in "${FILES[@]}"
+do
+    if [ ! -e "data/$filename" ]; then
+        RELOAD=true
+    fi
+done
+
+if [ "$RELOAD" = "true" ]; then
+    if [ -d "data/" ]; then rm -Rf "data/"; fi
     mkdir -p data
     wget https://raw.githubusercontent.com/HazyResearch/snorkel/master/tutorials/crowdsourcing/data/weather-non-agg-DFE.csv -P data
     wget https://d1p17r2m4rzlbo.cloudfront.net/wp-content/uploads/2016/03/weather-evaluated-agg-DFE.csv -P data

--- a/crowdsourcing/download-data.sh
+++ b/crowdsourcing/download-data.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euxo pipefail
+trap 'rm -r data/' ERR  # Clean up in case of error.
 
 if [ ! -d "data" ]; then
     mkdir -p data
-    wget https://raw.githubusercontent.com/HazyResearch/snorkel/master/tutorials/crowdsourcing/data/weather-non-agg-DFE.csv -P data
+    wget https://abcdraw.githubusercontent.com/HazyResearch/snorkel/master/tutorials/crowdsourcing/data/weather-non-agg-DFE.csv -P data
     wget https://d1p17r2m4rzlbo.cloudfront.net/wp-content/uploads/2016/03/weather-evaluated-agg-DFE.csv -P data
 fi

--- a/scene_graph/download_data.sh
+++ b/scene_graph/download_data.sh
@@ -1,5 +1,5 @@
 # Execute from snorkel-tutorials/
-# Download data,
+set -euxo pipefail
 
 ANNOTATIONS_URL="https://www.dropbox.com/s/bnfhm6kt9xumik8/vrd.zip"
 IMAGES_URL="http://imagenet.stanford.edu/internal/jcjohns/scene_graphs/sg_dataset.zip"

--- a/scene_graph/download_data.sh
+++ b/scene_graph/download_data.sh
@@ -1,5 +1,6 @@
 # Execute from snorkel-tutorials/
 set -euxo pipefail
+trap 'rm -r scene_graph/data/' ERR  # Clean up in case of error.
 
 ANNOTATIONS_URL="https://www.dropbox.com/s/bnfhm6kt9xumik8/vrd.zip"
 IMAGES_URL="http://imagenet.stanford.edu/internal/jcjohns/scene_graphs/sg_dataset.zip"

--- a/scene_graph/download_data.sh
+++ b/scene_graph/download_data.sh
@@ -1,6 +1,21 @@
-# Execute from snorkel-tutorials/
+#!/bin/bash
 set -euxo pipefail
-trap 'rm -r scene_graph/data/' ERR  # Clean up in case of error.
+
+# Check that we are running from the right directory.
+if [ ! "${PWD##*/}" = "snorkel-tutorials" ]; then
+    echo "Script must be run from snorkel-tutorials directory" >&2
+    exit 1
+fi
+
+DIRS=("glove" "VRD/sg_dataset/samples")
+
+# Check if at least any file is missing. If so, reload all data.
+for directory_name in "${DIRS[@]}"
+do
+    if [ ! -d "scene_graph/data/$directory_name" ]; then
+        RELOAD=true
+    fi
+done
 
 ANNOTATIONS_URL="https://www.dropbox.com/s/bnfhm6kt9xumik8/vrd.zip"
 IMAGES_URL="http://imagenet.stanford.edu/internal/jcjohns/scene_graphs/sg_dataset.zip"
@@ -8,6 +23,7 @@ SAMPLE_IMAGES_URL="https://github.com/Prof-Lu-Cewu/Visual-Relationship-Detection
 GLOVE_URL="http://nlp.stanford.edu/data/wordvecs/glove.6B.zip"
 
 if [ ! -d "scene_graph/data" ]; then
+    if [ -d "scene_graph/data/" ]; then rm -Rf "scene_graph/data/"; fi
     mkdir -p scene_graph/data
     cd scene_graph/data
 

--- a/scene_graph/utils.py
+++ b/scene_graph/utils.py
@@ -60,7 +60,13 @@ def load_vrd_data():
 
     NOTE: Only loads semantic relationship examples.
     """
-    subprocess.call("bash scene_graph/download_data.sh", shell=True)
+    try:
+        subprocess.run(
+            ["bash", "scene_graph/download_data.sh"], check=True, stderr=subprocess.PIPE
+        )
+    except subprocess.CalledProcessError as e:
+        print(e.stderr.decode())
+        raise e
 
     relationships_train = json.load(open("scene_graph/data/VRD/annotations_train.json"))
     relationships_test = json.load(open("scene_graph/data/VRD/annotations_test.json"))

--- a/spam/download_data.sh
+++ b/spam/download_data.sh
@@ -1,5 +1,5 @@
 # Execute from snorkel-tutorials/spam/
-# Download data,
+set -euxo pipefail
 
 DATA_URL="https://archive.ics.uci.edu/ml/machine-learning-databases/00380/YouTube-Spam-Collection-v1.zip"
 

--- a/spam/download_data.sh
+++ b/spam/download_data.sh
@@ -1,10 +1,26 @@
-# Execute from snorkel-tutorials/spam/
+#!/bin/bash
 set -euxo pipefail
-trap 'rm -r data/ data.zip' ERR  # Clean up in case of error.
 
+# Check that we are running from the right directory.
+if [ ! "${PWD##*/}" = "spam" ]; then
+    echo "Script must be run from spam directory" >&2
+    exit 1
+fi
+
+FILES=( "Youtube01-Psy.csv" "Youtube02-KatyPerry.csv" "Youtube03-LMFAO.csv" "Youtube04-Eminem.csv" "Youtube05-Shakira.csv" )
 DATA_URL="https://archive.ics.uci.edu/ml/machine-learning-databases/00380/YouTube-Spam-Collection-v1.zip"
+RELOAD=false
 
-if [ ! -d "data" ]; then
+# Check if at least any file is missing. If so, reload all data.
+for filename in "${FILES[@]}"
+do
+    if [ ! -e "data/$filename" ]; then
+        RELOAD=true
+    fi
+done
+
+if [ "$RELOAD" = true ]; then
+    if [ -d "data/" ]; then rm -Rf "data/"; fi
     mkdir -p data
     wget $DATA_URL -O data.zip
     mv data.zip data/

--- a/spam/download_data.sh
+++ b/spam/download_data.sh
@@ -1,5 +1,6 @@
 # Execute from snorkel-tutorials/spam/
 set -euxo pipefail
+trap 'rm -r data/ data.zip' ERR  # Clean up in case of error.
 
 DATA_URL="https://archive.ics.uci.edu/ml/machine-learning-databases/00380/YouTube-Spam-Collection-v1.zip"
 

--- a/spam/utils.py
+++ b/spam/utils.py
@@ -13,7 +13,11 @@ def load_spam_dataset(load_train_labels: bool = False):
     # TODO:
     # Add reference to dataset
     # Send email to dataset owner: tuliocasagrande < AT > acm.org
-    subprocess.run(["bash", "download_data.sh"], check=True)
+    try:
+        subprocess.run(["bash", "download_data.sh"], check=True, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        print(e.stderr.decode())
+        raise e
     filenames = sorted(glob.glob("data/Youtube*.csv"))
 
     dfs = []

--- a/spouse/download_data.sh
+++ b/spouse/download_data.sh
@@ -1,10 +1,26 @@
-# Execute from root of snorkel-tutorials/
+#!/bin/bash
 set -euxo pipefail
-trap 'rm -r data/ data.zip' ERR  # Clean up in case of error.
+
+# Check that we are running from the right directory.
+if [ ! "${PWD##*/}" = "spouse" ]; then
+    echo "Script must be run from spouse directory" >&2
+    exit 1
+fi
 
 DATA_URL="https://www.dropbox.com/s/jmrvyaqew4zp9cy/spouse_data.zip"
+FILES=( "train_data.pkl" "dev_data.pkl" "test_data.pkl" "dbpedia.pkl" )
+RELOAD=false
 
-if [ ! -d "data" ]; then
+# Check if at least any file is missing. If so, reload all data.
+for filename in "${FILES[@]}"
+do
+    if [ ! -e "data/$filename" ]; then
+        RELOAD=true
+    fi
+done
+
+if [ "$RELOAD" = true ]; then
+    if [ -d "data/" ]; then rm -Rf "data/"; fi
     mkdir -p data
     wget $DATA_URL -O data.zip
     cd data/

--- a/spouse/download_data.sh
+++ b/spouse/download_data.sh
@@ -1,4 +1,5 @@
 # Execute from root of snorkel-tutorials/
+set -euxo pipefail
 
 DATA_URL="https://www.dropbox.com/s/jmrvyaqew4zp9cy/spouse_data.zip"
 

--- a/spouse/download_data.sh
+++ b/spouse/download_data.sh
@@ -1,5 +1,6 @@
 # Execute from root of snorkel-tutorials/
 set -euxo pipefail
+trap 'rm -r data/ data.zip' ERR  # Clean up in case of error.
 
 DATA_URL="https://www.dropbox.com/s/jmrvyaqew4zp9cy/spouse_data.zip"
 

--- a/spouse/utils.py
+++ b/spouse/utils.py
@@ -17,7 +17,11 @@ def load_data() -> Tuple[
         df_train: Training set examples dataframe.
         df_test, Y_test: Test set examples dataframe and 1D labels ndarray.
     """
-    subprocess.run(["bash", "download_data.sh"], check=True)
+    try:
+        subprocess.run(["bash", "download_data.sh"], check=True, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        print(e.stderr.decode())
+        raise e
     with open(os.path.join("data", "dev_data.pkl"), "rb") as f:
         df_dev = pickle.load(f)
         Y_dev = pickle.load(f)


### PR DESCRIPTION
Also add checks for current directory, and check existence of each file (except for scene_graph, where we just check the lower level directories because there are too many files). Delete data dir and refresh if any file is missing, otherwise skip download. 

**Test Plan**
Tox passes.

Example error in jupyter (produced by changing the url of the crowdsourcing data to an incorrect one):

<img width="1567" alt="Screen Shot 2019-08-07 at 10 50 37 PM" src="https://user-images.githubusercontent.com/3421656/62678328-10225900-b966-11e9-87fd-e6fb594a9e72.png">

Also tried removing a single file from data/ to check that it correctly refreshes the directory. 