### PR TITLE
[EASY] Rename SnorkelClassifier to MultitaskClassifier

### DIFF
--- a/multitask/multitask_tutorial.ipynb
+++ b/multitask/multitask_tutorial.ipynb
@@ -245,7 +245,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we'll define the `SnorkelClassifier`, a flexible multi-task classifier written in PyTorch that is built from a list of `Tasks`."
+    "Now we'll define the `MultitaskClassifier`, a flexible multi-task classifier written in PyTorch that is built from a list of `Tasks`."
    ]
   },
   {
@@ -259,7 +259,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A `Task` represents a path through a neural network. In `SnorkelClassifier`, this path corresponds to a particular sequence of PyTorch modules through which each example will make a forward pass.\n",
+    "A `Task` represents a path through a neural network. In `MultitaskClassifier`, this path corresponds to a particular sequence of PyTorch modules through which each example will make a forward pass.\n",
     "\n",
     "To specify this sequence of modules, each `Task` defines a **module pool** (a set of modules that it relies on) and a **task flow**—a sequence of `Operation`s. Each `Operation` defines a module and the inputs to feed to that module. These inputs are described with a list of tuples, where each tuple has the name of a previous operation (or the keyword `_input_` to denote the original input) and either the name of a field (e.g., if the output of that operation is a `dict`) or an index (e.g., if the output of that operation is a `list` or `tuple`). Most PyTorch modules output a single tensor, so most of the time, the second element of this tuple is 0.\n",
     "\n",
@@ -392,9 +392,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from snorkel.classification import SnorkelClassifier\n",
+    "from snorkel.classification import MultitaskClassifier\n",
     "\n",
-    "model = SnorkelClassifier([circle_task, square_task])"
+    "model = MultitaskClassifier([circle_task, square_task])"
    ]
   },
   {
@@ -484,7 +484,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To check your understanding of how to use the multi-task `SnorkelClassifier`, see if you can add a task to this multi-task model.\n",
+    "To check your understanding of how to use the multi-task `MultitaskClassifier`, see if you can add a task to this multi-task model.\n",
     "\n",
     "We'll generate the data for you (again, with a train, valid, and test split).\n",
     "Let's call it the `inv_circle_task`, since it will have the same distribution as our circle data, but with the inverted (flipped) labels.\n",
@@ -659,7 +659,7 @@
    "outputs": [],
    "source": [
     "# Add your new task to the list of tasks for creating the MTL model\n",
-    "model = SnorkelClassifier([circle_task, square_task])  # Update this line"
+    "model = MultitaskClassifier([circle_task, square_task])  # Update this line"
    ]
   },
   {

--- a/multitask/multitask_tutorial.py
+++ b/multitask/multitask_tutorial.py
@@ -136,14 +136,14 @@ for (split, square_X_split, square_Y_split) in [
 # ## Define Model
 
 # %% [markdown]
-# Now we'll define the `SnorkelClassifier` model, a PyTorch multi-task classifier.
+# Now we'll define the `MultitaskClassifier` model, a PyTorch multi-task classifier.
 # We'll instantiate it from a list of `Tasks`.
 
 # %% [markdown]
 # ### Tasks
 
 # %% [markdown]
-# A `Task` represents a path through a neural network. In `SnorkelClassifier`, this path corresponds to a particular sequence of PyTorch modules through which each example will make a forward pass.
+# A `Task` represents a path through a neural network. In `MultitaskClassifier`, this path corresponds to a particular sequence of PyTorch modules through which each example will make a forward pass.
 #
 # To specify this sequence of modules, each `Task` defines a **module pool** (a set of modules that it relies on) and a **task flow**—a sequence of `Operation`s.
 # Each `Operation` specifies a module and the inputs to feed to that module.
@@ -236,9 +236,9 @@ square_task = Task(
 # So because both the `square_task` and `circle_task` include "base_mlp" in their module pools, this module will be shared between the two tasks.
 
 # %%
-from snorkel.classification import SnorkelClassifier
+from snorkel.classification import MultitaskClassifier
 
-model = SnorkelClassifier([circle_task, square_task])
+model = MultitaskClassifier([circle_task, square_task])
 
 # %% [markdown]
 # ### Train Model
@@ -272,7 +272,7 @@ model.score(dataloaders)
 # # Your Turn
 
 # %% [markdown]
-# To check your understanding of how to use the multi-task `SnorkelClassifier`, see if you can add a task to this multi-task model.
+# To check your understanding of how to use the multi-task `MultitaskClassifier`, see if you can add a task to this multi-task model.
 #
 # We'll generate the data for you (again, with a train, valid, and test split).
 # Let's call it the `inv_circle_task`, since it will have the same distribution as our circle data, but with the inverted (flipped) labels.
@@ -361,7 +361,7 @@ all_dataloaders = dataloaders + [inv_dataloader]
 
 # %%
 # Add your new task to the list of tasks for creating the MTL model
-model = SnorkelClassifier([circle_task, square_task])  # Filled in by you
+model = MultitaskClassifier([circle_task, square_task])  # Filled in by you
 
 # %% [markdown]
 # ### Train the model

--- a/scene_graph/vrd_tutorial.ipynb
+++ b/scene_graph/vrd_tutorial.ipynb
@@ -653,9 +653,9 @@
     }
    ],
    "source": [
-    "from snorkel.classification import SnorkelClassifier, Trainer\n",
+    "from snorkel.classification import MultitaskClassifier, Trainer\n",
     "\n",
-    "model = SnorkelClassifier([pred_cls_task])\n",
+    "model = MultitaskClassifier([pred_cls_task])\n",
     "trainer = Trainer(\n",
     "    n_epochs=1,\n",
     "    lr=1e-3,\n",

--- a/scene_graph/vrd_tutorial.py
+++ b/scene_graph/vrd_tutorial.py
@@ -260,9 +260,9 @@ pred_cls_task = Task(
 # ### Train and Evaluate Model
 
 # %%
-from snorkel.classification import SnorkelClassifier, Trainer
+from snorkel.classification import MultitaskClassifier, Trainer
 
-model = SnorkelClassifier([pred_cls_task])
+model = MultitaskClassifier([pred_cls_task])
 trainer = Trainer(
     n_epochs=1,
     lr=1e-3,


### PR DESCRIPTION
Makes the necessary changes related to PR #1365 in the main `snorkel` repo (renaming this class).

**Test plan:**
`tox`
