### PR TITLE
[EASY] Update names of loss and output funcs

### DIFF
--- a/mtl/multitask_tutorial.py
+++ b/mtl/multitask_tutorial.py
@@ -188,13 +188,13 @@ task_flow = [op1, op2]
 # %%
 from functools import partial
 
-from snorkel.classification import Scorer, Task, ce_loss_from_outputs, softmax_from_outputs
+from snorkel.classification import Scorer, Task, cross_entropy_from_outputs, softmax_from_outputs
 
 circle_task = Task(
     name="circle_task",
     module_pool=module_pool,
     task_flow=task_flow,
-    loss_func=partial(ce_loss_from_outputs, "circle_head"),
+    loss_func=partial(cross_entropy_from_outputs, "circle_head"),
     output_func=partial(softmax_from_outputs, "circle_head"),
     scorer=Scorer(metrics=["accuracy"]),
 )

--- a/mtl/multitask_tutorial.py
+++ b/mtl/multitask_tutorial.py
@@ -188,14 +188,14 @@ task_flow = [op1, op2]
 # %%
 from functools import partial
 
-from snorkel.classification import Scorer, Task, ce_loss, softmax
+from snorkel.classification import Scorer, Task, ce_loss_from_outputs, softmax_from_outputs
 
 circle_task = Task(
     name="circle_task",
     module_pool=module_pool,
     task_flow=task_flow,
-    loss_func=partial(ce_loss, "circle_head"),
-    output_func=partial(softmax, "circle_head"),
+    loss_func=partial(ce_loss_from_outputs, "circle_head"),
+    output_func=partial(softmax_from_outputs, "circle_head"),
     scorer=Scorer(metrics=["accuracy"]),
 )
 

--- a/scene_graph/vrd_tutorial.py
+++ b/scene_graph/vrd_tutorial.py
@@ -212,7 +212,7 @@ import torchvision.models as models
 import torch.nn as nn
 
 from functools import partial
-from snorkel.classification import Scorer, Task, ce_loss, softmax
+from snorkel.classification import Scorer, Task
 
 
 # initialize pretrained feature extractor
@@ -250,8 +250,6 @@ pred_cls_task = Task(
     name="scene_graph_task",
     module_pool=module_pool,
     task_flow=task_flow,
-    loss_func=partial(ce_loss, "head_op"),
-    output_func=partial(softmax, "head_op"),
     scorer=Scorer(metrics=["f1_micro"]),
 )
 


### PR DESCRIPTION
Update names and paths of loss and output funcs resulting from PR #1366 in main Snorkel repo.

**Test plan:**
`tox`