### PR TITLE
Revisions to crowdsourcing tutorial

### DIFF
--- a/crowdsourcing/crowdsourcing_tutorial.ipynb
+++ b/crowdsourcing/crowdsourcing_tutorial.ipynb
@@ -4,55 +4,46 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Crowdsourcing tutorial\n",
-    "In this tutorial, we'll provide a simple walkthrough of how to use Snorkel alongside crowdsourcing to generate labels for a sentiment analysis task.\n",
-    "We have crowdsourced labels for about half of the training dataset.\n",
-    "The crowdsourcing labels are of a fairly high quality, but do not cover the entire training dataset, nor are they available for the test set or during inference.\n",
-    "To make up for their lack of training set coverage, we combine crowdsourcing labels with heuristic labeling functions to increase the number of training labels we have.\n",
-    "Like most Snorkel labeling pipelines, we'll use the denoised labels to train a deep learning\n",
-    "model which can be applied to new, unseen data to automatically make predictions!\n",
-    "\n",
-    "In this tutorial, we're using the\n",
-    "[Weather Sentiment](https://data.world/crowdflower/weather-sentiment)\n",
-    "dataset from Figure Eight.\n",
-    "Our goal is to label each tweet as either positive or negative so that\n",
-    "we can train a language model over the tweets themselves that can be applied\n",
-    "to new, unseen data points.\n",
-    "Crowd workers were asked to grade the sentiment of a\n",
-    "particular tweet relating to the weather. They could say it was positive or\n",
-    "negative, or choose one of three other options saying they weren't sure it was\n",
-    "positive or negative.\n",
-    "\n",
-    "The catch is that 20 crowd workers graded each tweet, and in many cases\n",
-    "crowd workers assigned conflicting sentiment labels to the same tweet.\n",
-    "This is a common issue when dealing with crowdsourced labeling workloads.\n",
-    "\n",
-    "We've also altered the data set to reflect a realistic crowdsourcing pipeline\n",
-    "where only a subset of our full training set have recieved crowd labels.\n",
-    "Since our objective is to classify tweets as positive or negative, we limited\n",
-    "the dataset to tweets that were either positive or negative.\n",
-    "\n",
-    "We'll encode the crowd labels themselves as labeling functions in order\n",
-    "to learn trust weights for each crowd worker, and write a few heuristic\n",
-    "labeling functions to cover the data points without crowd labels.\n",
-    "Snorkel's ability to build high-quality datasets from multiple noisy labeling\n",
-    "signals makes it an ideal framework to approach this problem."
+    "# Crowdsourcing Tutorial"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We start by loading our data which has 287 examples in total.\n",
-    "We take 50 for our development set and 50 for our test set.\n",
-    "The remaining 187 examples form our training set.\n",
-    "This data set is very small, and we're primarily using it for demonstration purposes.\n",
-    "In particular, we'd expect to have access to many more unlabeled tweets in order to\n",
-    "train a high performance text model.\n",
-    "Since the dataset is already small, we skip\n",
-    "using a validation set.\n",
+    "In this tutorial, we'll provide a simple walkthrough of how to use Snorkel in conjuction with crowdsourcing to create a training set for a sentiment analysis task.\n",
+    "We already have crowdsourced labels for about half of the training dataset.\n",
+    "The crowdsourced labels are fairly accurate, but do not cover the entire training dataset, nor are they available for the test set or during inference.\n",
+    "To make up for their lack of training set coverage, we combine crowdsourced labels with heuristic labeling functions to increase the number of training labels we have.\n",
+    "Like most Snorkel labeling pipelines, we'll use the denoised labels to train a deep learning\n",
+    "model which can be applied to new, unseen data to automatically make predictions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dataset Details"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial, we'll use the [Weather Sentiment](https://data.world/crowdflower/weather-sentiment) dataset from Figure Eight.\n",
+    "Our goal is to train a classifier that can label new tweets as expressing either a positive or negative sentiment.\n",
     "\n",
-    "The labels above have been mapped to integers, which we show here."
+    "Crowdworkers were asked to label the sentiment of a particular tweet relating to the weather.\n",
+    "The catch is that 20 crowdworkers graded each tweet, and in many cases crowdworkers assigned conflicting sentiment labels to the same tweet.\n",
+    "This is a common issue when dealing with crowdsourced labeling workloads.\n",
+    "\n",
+    "Label options were positive, negative, or one of three other options saying they weren't sure if it was positive or negative; we use only the positive/negative labels.\n",
+    "We've also altered the dataset to reflect a realistic crowdsourcing pipeline where only a subset of our available training set have recieved crowd labels.\n",
+    "\n",
+    "We will treat each crowdworker's labels as coming from a single labeling function (LF).\n",
+    "This will allow us to learn a weight for how much much to trust the labels from each crowdworker.\n",
+    "We will also write a few heuristic labeling functions to cover the data points without crowd labels.\n",
+    "Snorkel's ability to build high-quality datasets from multiple noisy labeling signals makes it an ideal framework to approach this problem."
    ]
   },
   {
@@ -63,6 +54,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start by loading our data which has 287 examples in total.\n",
+    "We take 50 for our development set and 50 for our test set.\n",
+    "The remaining 187 examples form our training set.\n",
+    "Since the dataset is already small, we skip using a validation set.\n",
+    "Note that this very small dataset is primarily used for demonstration purposes here.\n",
+    "In a real setting, we would expect to have access to many more unlabeled tweets, which could help us to train a higher quality model."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -70,6 +73,7 @@
    "source": [
     "import os\n",
     "\n",
+    "# Make sure we're in the right directory\n",
     "if os.path.basename(os.getcwd()) == \"snorkel-tutorials\":\n",
     "    os.chdir(\"crowdsourcing\")"
    ]
@@ -78,38 +82,21 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Answer to int mapping:\n",
-      "I can't tell                                      -1\n",
-      "Negative                                          0\n",
-      "Positive                                          1\n",
-      "Neutral / author is just sharing information      2\n",
-      "Tweet not related to weather condition            3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from data import load_data, answer_mapping\n",
+    "from data import load_data\n",
     "\n",
-    "crowd_answers, df_train, df_dev, df_test = load_data()\n",
+    "crowd_labels, df_train, df_dev, df_test = load_data()\n",
     "Y_dev = df_dev.sentiment.values\n",
-    "Y_test = df_test.sentiment.values\n",
-    "\n",
-    "print(\"Answer to int mapping:\")\n",
-    "for k, v in sorted(answer_mapping.items(), key=lambda kv: kv[1]):\n",
-    "    print(f\"{k:<50}{v}\")"
+    "Y_test = df_test.sentiment.values"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, let's take a look at our development set to get a sense of\n",
-    "what the tweets look like."
+    "First, let's take a look at our development set to get a sense of what the tweets look like.  \n",
+    "We use the following label convention: 0 = Negative, 1 = Positive."
    ]
   },
   {
@@ -259,7 +246,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>worker_id</th>\n",
-       "      <th>answer</th>\n",
+       "      <th>label</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>tweet_id</th>\n",
@@ -298,13 +285,13 @@
        "</div>"
       ],
       "text/plain": [
-       "          worker_id  answer\n",
-       "tweet_id                   \n",
-       "82510997  18034918   1     \n",
-       "82510997  7450342    1     \n",
-       "82510997  18465660   1     \n",
-       "82510997  17475684   0     \n",
-       "82510997  14472526   1     "
+       "          worker_id  label\n",
+       "tweet_id                  \n",
+       "82510997  18034918   1    \n",
+       "82510997  7450342    1    \n",
+       "82510997  18465660   1    \n",
+       "82510997  17475684   0    \n",
+       "82510997  14472526   1    "
       ]
      },
      "execution_count": 4,
@@ -313,7 +300,7 @@
     }
    ],
    "source": [
-    "crowd_answers.head()"
+    "crowd_labels.head()"
    ]
   },
   {
@@ -321,19 +308,19 @@
    "metadata": {},
    "source": [
     "## Writing Labeling Functions\n",
-    "Each crowd worker can be thought of as a single labeling function,\n",
+    "Each crowdworker can be thought of as a single labeling function,\n",
     "as each worker labels a subset of examples,\n",
-    "and may have errors or conflicting answers with other workers / labeling functions.\n",
+    "and may have errors or conflicting labels with other workers / labeling functions.\n",
     "So we create one labeling function per worker.\n",
     "We'll simply return the label the worker submitted for a given tweet, and abstain\n",
-    "if they didn't submit an answer for it."
+    "if they didn't submit a label for it."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Crowd worker labeling functions"
+    "### Crowdworker labeling functions"
    ]
   },
   {
@@ -345,17 +332,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of workers: 68\n"
+      "Number of workers: 100\n"
      ]
     }
    ],
    "source": [
-    "labels_by_annotator = crowd_answers.groupby(\"worker_id\")\n",
+    "labels_by_annotator = crowd_labels.groupby(\"worker_id\")\n",
     "worker_dicts = {}\n",
     "for worker_id in labels_by_annotator.groups:\n",
-    "    worker_df = labels_by_annotator.get_group(worker_id)[[\"answer\"]]\n",
-    "    if len(worker_df) > 10:\n",
-    "        worker_dicts[worker_id] = dict(zip(worker_df.index, worker_df.answer))\n",
+    "    worker_df = labels_by_annotator.get_group(worker_id)[[\"label\"]]\n",
+    "    worker_dicts[worker_id] = dict(zip(worker_df.index, worker_df.label))\n",
     "\n",
     "print(\"Number of workers:\", len(worker_dicts))"
    ]
@@ -368,29 +354,18 @@
    "source": [
     "from snorkel.labeling import LabelingFunction\n",
     "\n",
+    "ABSTAIN = -1\n",
     "\n",
-    "def f_pos(x, worker_dict):\n",
-    "    label = worker_dict.get(x.tweet_id)\n",
-    "    return 1 if label == 1 else -1\n",
+    "def worker_lf(x, worker_dict):\n",
+    "    return worker_dict.get(x.tweet_id, ABSTAIN)\n",
     "\n",
-    "\n",
-    "def f_neg(x, worker_dict):\n",
-    "    label = worker_dict.get(x.tweet_id)\n",
-    "    return 0 if label == 0 else -1\n",
-    "\n",
-    "\n",
-    "def get_worker_labeling_function(worker_id, f):\n",
+    "def make_worker_lf(worker_id):\n",
     "    worker_dict = worker_dicts[worker_id]\n",
-    "    name = f\"worker_{worker_id}_{f.__name__}\"\n",
-    "    return LabelingFunction(name, f=f, resources={\"worker_dict\": worker_dict})\n",
+    "    name = f\"worker_{worker_id}\"\n",
+    "    return LabelingFunction(name, f=worker_lf, resources={\"worker_dict\": worker_dict})\n",
     "\n",
     "\n",
-    "worker_lfs_pos = [\n",
-    "    get_worker_labeling_function(worker_id, f_pos) for worker_id in worker_dicts\n",
-    "]\n",
-    "worker_lfs_neg = [\n",
-    "    get_worker_labeling_function(worker_id, f_neg) for worker_id in worker_dicts\n",
-    "]"
+    "worker_lfs = [make_worker_lf(worker_id) for worker_id in worker_dicts]"
    ]
   },
   {
@@ -418,7 +393,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 42%|████▏     | 79/187 [00:00<00:00, 789.58it/s]"
+      " 36%|███▋      | 68/187 [00:00<00:00, 676.45it/s]"
      ]
     },
     {
@@ -426,7 +401,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 85%|████████▌ | 159/187 [00:00<00:00, 791.92it/s]"
+      " 80%|███████▉  | 149/187 [00:00<00:00, 709.93it/s]"
      ]
     },
     {
@@ -434,7 +409,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 187/187 [00:00<00:00, 785.83it/s]"
+      "100%|██████████| 187/187 [00:00<00:00, 763.37it/s]"
      ]
     },
     {
@@ -451,7 +426,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 50/50 [00:00<00:00, 781.14it/s]"
+      "100%|██████████| 50/50 [00:00<00:00, 893.80it/s]"
      ]
     },
     {
@@ -465,11 +440,17 @@
    "source": [
     "from snorkel.labeling import PandasLFApplier\n",
     "\n",
-    "lfs = worker_lfs_pos + worker_lfs_neg\n",
-    "\n",
-    "applier = PandasLFApplier(lfs)\n",
+    "applier = PandasLFApplier(worker_lfs)\n",
     "L_train = applier.apply(df_train)\n",
     "L_dev = applier.apply(df_dev)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that because our dev set is so small and our LFs are relatively sparse, many LFs will appear to have zero coverage.\n",
+    "Fortunately, our label model learns weights for LFs based on their coverage on the training set, which is generally much larger."
    ]
   },
   {
@@ -510,78 +491,78 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>worker_6340330_f_pos</th>\n",
-       "      <td>0</td>\n",
-       "      <td>[1]</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>2</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>worker_6344001_f_pos</th>\n",
+       "      <th>worker_17594578</th>\n",
+       "      <td>69</td>\n",
+       "      <td>[0, 1]</td>\n",
+       "      <td>0.16</td>\n",
+       "      <td>0.16</td>\n",
+       "      <td>0.14</td>\n",
+       "      <td>7</td>\n",
        "      <td>1</td>\n",
-       "      <td>[1]</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>2</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>0.875</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_6346694_f_pos</th>\n",
-       "      <td>2</td>\n",
-       "      <td>[1]</td>\n",
+       "      <th>worker_20095709</th>\n",
+       "      <td>99</td>\n",
+       "      <td>[0, 1]</td>\n",
        "      <td>0.12</td>\n",
        "      <td>0.12</td>\n",
        "      <td>0.10</td>\n",
-       "      <td>5</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0.833333</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_6363996_f_pos</th>\n",
-       "      <td>3</td>\n",
-       "      <td>[1]</td>\n",
+       "      <th>worker_18081456</th>\n",
+       "      <td>74</td>\n",
+       "      <td>[0, 1]</td>\n",
        "      <td>0.04</td>\n",
        "      <td>0.04</td>\n",
-       "      <td>0.02</td>\n",
+       "      <td>0.04</td>\n",
        "      <td>2</td>\n",
        "      <td>0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_6371053_f_pos</th>\n",
-       "      <td>4</td>\n",
+       "      <th>worker_19415027</th>\n",
+       "      <td>94</td>\n",
        "      <td>[1]</td>\n",
-       "      <td>0.06</td>\n",
-       "      <td>0.06</td>\n",
-       "      <td>0.06</td>\n",
-       "      <td>2</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>0.02</td>\n",
        "      <td>1</td>\n",
-       "      <td>0.666667</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>worker_18806438</th>\n",
+       "      <td>84</td>\n",
+       "      <td>[0, 1]</td>\n",
+       "      <td>0.10</td>\n",
+       "      <td>0.10</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                      j Polarity  Coverage  Overlaps  Conflicts  Correct  \\\n",
-       "worker_6340330_f_pos  0  [1]      0.04      0.04      0.04       2         \n",
-       "worker_6344001_f_pos  1  [1]      0.04      0.04      0.04       2         \n",
-       "worker_6346694_f_pos  2  [1]      0.12      0.12      0.10       5         \n",
-       "worker_6363996_f_pos  3  [1]      0.04      0.04      0.02       2         \n",
-       "worker_6371053_f_pos  4  [1]      0.06      0.06      0.06       2         \n",
+       "                  j Polarity  Coverage  Overlaps  Conflicts  Correct  \\\n",
+       "worker_17594578  69  [0, 1]   0.16      0.16      0.14       7         \n",
+       "worker_20095709  99  [0, 1]   0.12      0.12      0.10       6         \n",
+       "worker_18081456  74  [0, 1]   0.04      0.04      0.04       2         \n",
+       "worker_19415027  94  [1]      0.02      0.02      0.02       1         \n",
+       "worker_18806438  84  [0, 1]   0.10      0.10      0.08       5         \n",
        "\n",
-       "                      Incorrect  Emp. Acc.  \n",
-       "worker_6340330_f_pos  0          1.000000   \n",
-       "worker_6344001_f_pos  0          1.000000   \n",
-       "worker_6346694_f_pos  1          0.833333   \n",
-       "worker_6363996_f_pos  0          1.000000   \n",
-       "worker_6371053_f_pos  1          0.666667   "
+       "                 Incorrect  Emp. Acc.  \n",
+       "worker_17594578  1          0.875      \n",
+       "worker_20095709  0          1.000      \n",
+       "worker_18081456  0          1.000      \n",
+       "worker_19415027  0          1.000      \n",
+       "worker_18806438  0          1.000      "
       ]
      },
      "execution_count": 8,
@@ -592,14 +573,14 @@
    "source": [
     "from snorkel.labeling import LFAnalysis\n",
     "\n",
-    "LFAnalysis(L_dev, lfs).lf_summary(Y_dev).head()"
+    "LFAnalysis(L_dev, worker_lfs).lf_summary(Y_dev).sample(5)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So the crowd labels are quite good! But how much of our dev and training\n",
+    "So the crowd labels in general are quite good! But how much of our dev and training\n",
     "sets do they cover?"
    ]
   },
@@ -612,14 +593,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training set coverage: 0.5026737967914439\n",
-      "Dev set coverage: 0.5\n"
+      "Training set coverage:  0.503\n",
+      "Dev set coverage:  0.500\n"
      ]
     }
    ],
    "source": [
-    "print(\"Training set coverage:\", LFAnalysis(L_train).label_coverage())\n",
-    "print(\"Dev set coverage:\", LFAnalysis(L_dev).label_coverage())"
+    "print(f\"Training set coverage: {LFAnalysis(L_train).label_coverage(): 0.3f}\")\n",
+    "print(f\"Dev set coverage: {LFAnalysis(L_dev).label_coverage(): 0.3f}\")"
    ]
   },
   {
@@ -628,7 +609,7 @@
    "source": [
     "### Additional labeling functions\n",
     "\n",
-    "To improve coverage of the training set, we can mix the crowd worker labeling functions with labeling\n",
+    "To improve coverage of the training set, we can mix the crowdworker labeling functions with labeling\n",
     "functions of other types.\n",
     "For example, we can use [TextBlob](https://textblob.readthedocs.io/en/dev/index.html), a tool that provides a pretrained sentiment analyzer. We run TextBlob on our tweets and create some simple LFs that threshold its polarity score, similar to what we did in the spam_tutorial."
    ]
@@ -644,14 +625,12 @@
     "from textblob import TextBlob\n",
     "\n",
     "\n",
-    "@preprocessor()\n",
+    "@preprocessor(memoize=True)\n",
     "def textblob_polarity(x):\n",
     "    scores = TextBlob(x.tweet_text)\n",
     "    x.polarity = scores.polarity\n",
     "    return x\n",
     "\n",
-    "\n",
-    "textblob_polarity.memoize = True\n",
     "\n",
     "# Label high polarity tweets as positive.\n",
     "@labeling_function(pre=[textblob_polarity])\n",
@@ -696,7 +675,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 16%|█▌        | 30/187 [00:00<00:00, 298.53it/s]"
+      " 13%|█▎        | 24/187 [00:00<00:00, 235.68it/s]"
      ]
     },
     {
@@ -704,7 +683,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 41%|████      | 76/187 [00:00<00:00, 332.71it/s]"
+      " 36%|███▋      | 68/187 [00:00<00:00, 272.91it/s]"
      ]
     },
     {
@@ -712,7 +691,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 65%|██████▌   | 122/187 [00:00<00:00, 361.35it/s]"
+      " 64%|██████▎   | 119/187 [00:00<00:00, 316.56it/s]"
      ]
     },
     {
@@ -720,7 +699,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 90%|████████▉ | 168/187 [00:00<00:00, 384.21it/s]"
+      " 94%|█████████▎| 175/187 [00:00<00:00, 363.26it/s]"
      ]
     },
     {
@@ -728,7 +707,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 187/187 [00:00<00:00, 414.78it/s]"
+      "100%|██████████| 187/187 [00:00<00:00, 435.34it/s]"
      ]
     },
     {
@@ -745,15 +724,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 92%|█████████▏| 46/50 [00:00<00:00, 459.38it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 50/50 [00:00<00:00, 445.14it/s]"
+      "100%|██████████| 50/50 [00:00<00:00, 520.98it/s]"
      ]
     },
     {
@@ -766,7 +737,7 @@
    ],
    "source": [
     "text_lfs = [polarity_positive, polarity_negative, polarity_negative_2]\n",
-    "lfs = text_lfs + worker_lfs_pos + worker_lfs_neg\n",
+    "lfs = text_lfs + worker_lfs\n",
     "\n",
     "applier = PandasLFApplier(lfs)\n",
     "L_train = applier.apply(df_train)\n",
@@ -844,45 +815,45 @@
        "      <td>0.742857</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_6340330_f_pos</th>\n",
+       "      <th>worker_6332651</th>\n",
        "      <td>3</td>\n",
-       "      <td>[1]</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
+       "      <td>[0, 1]</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>1</td>\n",
        "      <td>2</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>0.333333</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_6344001_f_pos</th>\n",
+       "      <th>worker_6336109</th>\n",
        "      <td>4</td>\n",
-       "      <td>[1]</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>2</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.00</td>\n",
        "      <td>0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                      j Polarity  Coverage  Overlaps  Conflicts  Correct  \\\n",
-       "polarity_positive     0  [1]      0.30      0.16      0.12       15        \n",
-       "polarity_negative     1  [0]      0.10      0.10      0.04       5         \n",
-       "polarity_negative_2   2  [0]      0.70      0.40      0.32       26        \n",
-       "worker_6340330_f_pos  3  [1]      0.04      0.04      0.04       2         \n",
-       "worker_6344001_f_pos  4  [1]      0.04      0.04      0.04       2         \n",
+       "                     j Polarity  Coverage  Overlaps  Conflicts  Correct  \\\n",
+       "polarity_positive    0  [1]      0.30      0.16      0.12       15        \n",
+       "polarity_negative    1  [0]      0.10      0.10      0.04       5         \n",
+       "polarity_negative_2  2  [0]      0.70      0.40      0.32       26        \n",
+       "worker_6332651       3  [0, 1]   0.06      0.06      0.06       1         \n",
+       "worker_6336109       4  []       0.00      0.00      0.00       0         \n",
        "\n",
-       "                      Incorrect  Emp. Acc.  \n",
-       "polarity_positive     0          1.000000   \n",
-       "polarity_negative     0          1.000000   \n",
-       "polarity_negative_2   9          0.742857   \n",
-       "worker_6340330_f_pos  0          1.000000   \n",
-       "worker_6344001_f_pos  0          1.000000   "
+       "                     Incorrect  Emp. Acc.  \n",
+       "polarity_positive    0          1.000000   \n",
+       "polarity_negative    0          1.000000   \n",
+       "polarity_negative_2  9          0.742857   \n",
+       "worker_6332651       2          0.333333   \n",
+       "worker_6336109       0          0.000000   "
       ]
      },
      "execution_count": 12,
@@ -913,14 +884,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training set coverage: 1.0\n",
-      "Dev set coverage: 1.0\n"
+      "Training set coverage:  1.000\n",
+      "Dev set coverage:  1.000\n"
      ]
     }
    ],
    "source": [
-    "print(\"Training set coverage:\", LFAnalysis(L_train).label_coverage())\n",
-    "print(\"Dev set coverage:\", LFAnalysis(L_dev).label_coverage())"
+    "print(f\"Training set coverage: {LFAnalysis(L_train).label_coverage(): 0.3f}\")\n",
+    "print(f\"Dev set coverage: {LFAnalysis(L_dev).label_coverage(): 0.3f}\")"
    ]
   },
   {
@@ -978,22 +949,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Look at that, we get very high accuracy on the development set.\n",
-    "This is due to the abundance of high quality crowd worker labels.\n",
+    "We see that we get very high accuracy on the development set.\n",
+    "This is due to the abundance of high quality crowdworker labels.\n",
     "**Since we don't have these high quality crowdsourcing labels for the\n",
     "test set or new incoming examples, we can't use the LabelModel reliably\n",
     "at inference time.**\n",
     "In order to run inference on new incoming examples, we need to train a\n",
     "discriminative model over the tweets themselves.\n",
-    "Let's generate a set of probabilistic labels for the training set."
+    "Let's generate a set of probabilistic labels for that training set."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -1016,7 +980,9 @@
    "metadata": {},
    "source": [
     "### Getting features from BERT\n",
-    "Since we have very limited training data, we cannot train a complex model like an LSTM with a lot of parameters. Instead, we use a pre-trained model, [BERT](https://github.com/google-research/bert), to generate embeddings for each our tweets, and treat the embedding values as features."
+    "Since we have very limited training data, we cannot train a complex model like an LSTM with a lot of parameters. \n",
+    "Instead, we use a pre-trained model, [BERT](https://github.com/google-research/bert), to generate embeddings for each our tweets, and treat the embedding values as features.\n",
+    "This may take 5-10 minutes on a CPU, as the BERT model is very large."
    ]
   },
   {
@@ -1057,6 +1023,33 @@
    "metadata": {},
    "outputs": [
     {
+     "data": {
+      "text/plain": [
+       "LogisticRegression(C=1.0, class_weight=None, dual=False, fit_intercept=True,\n",
+       "                   intercept_scaling=1, l1_ratio=None, max_iter=100,\n",
+       "                   multi_class='warn', n_jobs=None, penalty='l2',\n",
+       "                   random_state=None, solver='liblinear', tol=0.0001, verbose=0,\n",
+       "                   warm_start=False)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "sklearn_model = LogisticRegression(solver=\"liblinear\")\n",
+    "sklearn_model.fit(train_vectors, probs_to_preds(Y_train_prob))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -1065,11 +1058,6 @@
     }
    ],
    "source": [
-    "from sklearn.linear_model import LogisticRegression\n",
-    "\n",
-    "sklearn_model = LogisticRegression(solver=\"liblinear\")\n",
-    "sklearn_model.fit(train_vectors, probs_to_preds(Y_train_prob))\n",
-    "\n",
     "print(f\"Accuracy of trained model: {sklearn_model.score(test_vectors, Y_test)}\")"
    ]
   },
@@ -1077,7 +1065,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now have a model with accuracy not much lower than the LabelModel, but with the advantage of being faster and cheaper than crowdsourcing, and applicable to all future examples."
+    "We now have a trained model that can be applied to future examples without requiring crowdsourced labels, and with accuracy not much lower than the `LabelModel` that _does_ have access to crowdsourced labels! "
    ]
   },
   {
@@ -1087,9 +1075,9 @@
     "## Summary\n",
     "\n",
     "In this tutorial, we accomplished the following:\n",
-    "* We showed how Snorkel can handle crowdsourced labels, combining them with other programmatic LFs to improve coverage.\n",
-    "* We showed how the LabelModel learns to combine inputs from crowd workers and other LFs by appropriately weighting them to generate high quality probabilistic labels.\n",
-    "* We showed that a classifier trained on the combined labels can achieve a fairly high accuracy while also generalizing to new, unseen examples."
+    "* We demonstrated how to combine crowdsourced labels with other programmatic LFs to improve coverage.\n",
+    "* We used the `LabelModel` to learn how to combine inputs from crowdworkers and other LFs to generate high quality probabilistic labels.\n",
+    "* We used our probabilistic labels to train a classifier for making predictions on new, unseen examples."
    ]
   }
  ],
@@ -1112,7 +1100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/crowdsourcing/crowdsourcing_tutorial.ipynb
+++ b/crowdsourcing/crowdsourcing_tutorial.ipynb
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, let's take a look at our development set to get a sense of what the tweets look like.  \n",
+    "First, let's take a look at our development set to get a sense of what the tweets look like.\n",
     "We use the following label convention: 0 = Negative, 1 = Positive."
    ]
   },
@@ -356,8 +356,10 @@
     "\n",
     "ABSTAIN = -1\n",
     "\n",
+    "\n",
     "def worker_lf(x, worker_dict):\n",
     "    return worker_dict.get(x.tweet_id, ABSTAIN)\n",
+    "\n",
     "\n",
     "def make_worker_lf(worker_id):\n",
     "    worker_dict = worker_dicts[worker_id]\n",
@@ -393,7 +395,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 36%|███▋      | 68/187 [00:00<00:00, 676.45it/s]"
+      " 46%|████▌     | 86/187 [00:00<00:00, 855.44it/s]"
      ]
     },
     {
@@ -401,7 +403,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 80%|███████▉  | 149/187 [00:00<00:00, 709.93it/s]"
+      " 95%|█████████▌| 178/187 [00:00<00:00, 871.22it/s]"
      ]
     },
     {
@@ -409,7 +411,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 187/187 [00:00<00:00, 763.37it/s]"
+      "100%|██████████| 187/187 [00:00<00:00, 874.55it/s]"
      ]
     },
     {
@@ -426,7 +428,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 50/50 [00:00<00:00, 893.80it/s]"
+      "100%|██████████| 50/50 [00:00<00:00, 918.63it/s]"
      ]
     },
     {
@@ -491,59 +493,59 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>worker_17594578</th>\n",
-       "      <td>69</td>\n",
+       "      <th>worker_14466721</th>\n",
+       "      <td>46</td>\n",
+       "      <td>[0, 1]</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>worker_19715431</th>\n",
+       "      <td>95</td>\n",
        "      <td>[0, 1]</td>\n",
        "      <td>0.16</td>\n",
        "      <td>0.16</td>\n",
        "      <td>0.14</td>\n",
-       "      <td>7</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0.875</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>worker_20095709</th>\n",
-       "      <td>99</td>\n",
-       "      <td>[0, 1]</td>\n",
-       "      <td>0.12</td>\n",
-       "      <td>0.12</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>6</td>\n",
+       "      <td>8</td>\n",
        "      <td>0</td>\n",
-       "      <td>1.000</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_18081456</th>\n",
-       "      <td>74</td>\n",
+       "      <th>worker_16498372</th>\n",
+       "      <td>58</td>\n",
+       "      <td>[0, 1]</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>worker_18112936</th>\n",
+       "      <td>75</td>\n",
+       "      <td>[0, 1]</td>\n",
+       "      <td>0.10</td>\n",
+       "      <td>0.10</td>\n",
+       "      <td>0.10</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>worker_18500901</th>\n",
+       "      <td>81</td>\n",
        "      <td>[0, 1]</td>\n",
        "      <td>0.04</td>\n",
        "      <td>0.04</td>\n",
        "      <td>0.04</td>\n",
        "      <td>2</td>\n",
        "      <td>0</td>\n",
-       "      <td>1.000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>worker_19415027</th>\n",
-       "      <td>94</td>\n",
-       "      <td>[1]</td>\n",
-       "      <td>0.02</td>\n",
-       "      <td>0.02</td>\n",
-       "      <td>0.02</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1.000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>worker_18806438</th>\n",
-       "      <td>84</td>\n",
-       "      <td>[0, 1]</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.08</td>\n",
-       "      <td>5</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1.000</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -551,18 +553,18 @@
       ],
       "text/plain": [
        "                  j Polarity  Coverage  Overlaps  Conflicts  Correct  \\\n",
-       "worker_17594578  69  [0, 1]   0.16      0.16      0.14       7         \n",
-       "worker_20095709  99  [0, 1]   0.12      0.12      0.10       6         \n",
-       "worker_18081456  74  [0, 1]   0.04      0.04      0.04       2         \n",
-       "worker_19415027  94  [1]      0.02      0.02      0.02       1         \n",
-       "worker_18806438  84  [0, 1]   0.10      0.10      0.08       5         \n",
+       "worker_14466721  46  [0, 1]   0.06      0.06      0.04       3         \n",
+       "worker_19715431  95  [0, 1]   0.16      0.16      0.14       8         \n",
+       "worker_16498372  58  [0, 1]   0.06      0.06      0.04       3         \n",
+       "worker_18112936  75  [0, 1]   0.10      0.10      0.10       4         \n",
+       "worker_18500901  81  [0, 1]   0.04      0.04      0.04       2         \n",
        "\n",
        "                 Incorrect  Emp. Acc.  \n",
-       "worker_17594578  1          0.875      \n",
-       "worker_20095709  0          1.000      \n",
-       "worker_18081456  0          1.000      \n",
-       "worker_19415027  0          1.000      \n",
-       "worker_18806438  0          1.000      "
+       "worker_14466721  0          1.0        \n",
+       "worker_19715431  0          1.0        \n",
+       "worker_16498372  0          1.0        \n",
+       "worker_18112936  1          0.8        \n",
+       "worker_18500901  0          1.0        "
       ]
      },
      "execution_count": 8,
@@ -675,7 +677,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 13%|█▎        | 24/187 [00:00<00:00, 235.68it/s]"
+      " 16%|█▌        | 30/187 [00:00<00:00, 296.34it/s]"
      ]
     },
     {
@@ -683,7 +685,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 36%|███▋      | 68/187 [00:00<00:00, 272.91it/s]"
+      " 47%|████▋     | 88/187 [00:00<00:00, 347.16it/s]"
      ]
     },
     {
@@ -691,7 +693,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 64%|██████▎   | 119/187 [00:00<00:00, 316.56it/s]"
+      " 79%|███████▊  | 147/187 [00:00<00:00, 395.49it/s]"
      ]
     },
     {
@@ -699,7 +701,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 94%|█████████▎| 175/187 [00:00<00:00, 363.26it/s]"
+      " 99%|█████████▉| 186/187 [00:00<00:00, 390.94it/s]"
      ]
     },
     {
@@ -707,7 +709,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 187/187 [00:00<00:00, 435.34it/s]"
+      "100%|██████████| 187/187 [00:00<00:00, 455.41it/s]"
      ]
     },
     {
@@ -724,7 +726,15 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 50/50 [00:00<00:00, 520.98it/s]"
+      " 98%|█████████▊| 49/50 [00:00<00:00, 488.52it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 50/50 [00:00<00:00, 477.11it/s]"
      ]
     },
     {
@@ -980,7 +990,7 @@
    "metadata": {},
    "source": [
     "### Getting features from BERT\n",
-    "Since we have very limited training data, we cannot train a complex model like an LSTM with a lot of parameters. \n",
+    "Since we have very limited training data, we cannot train a complex model like an LSTM with a lot of parameters.\n",
     "Instead, we use a pre-trained model, [BERT](https://github.com/google-research/bert), to generate embeddings for each our tweets, and treat the embedding values as features.\n",
     "This may take 5-10 minutes on a CPU, as the BERT model is very large."
    ]
@@ -1065,7 +1075,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now have a trained model that can be applied to future examples without requiring crowdsourced labels, and with accuracy not much lower than the `LabelModel` that _does_ have access to crowdsourced labels! "
+    "We now have a trained model that can be applied to future examples without requiring crowdsourced labels, and with accuracy not much lower than the `LabelModel` that _does_ have access to crowdsourced labels!"
    ]
   },
   {

--- a/crowdsourcing/crowdsourcing_tutorial.ipynb
+++ b/crowdsourcing/crowdsourcing_tutorial.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this tutorial, we'll provide a simple walkthrough of how to use Snorkel in conjuction with crowdsourcing to create a training set for a sentiment analysis task.\n",
+    "In this tutorial, we'll provide a simple walkthrough of how to use Snorkel in conjunction with crowdsourcing to create a training set for a sentiment analysis task.\n",
     "We already have crowdsourced labels for about half of the training dataset.\n",
     "The crowdsourced labels are fairly accurate, but do not cover the entire training dataset, nor are they available for the test set or during inference.\n",
     "To make up for their lack of training set coverage, we combine crowdsourced labels with heuristic labeling functions to increase the number of training labels we have.\n",
@@ -38,10 +38,10 @@
     "This is a common issue when dealing with crowdsourced labeling workloads.\n",
     "\n",
     "Label options were positive, negative, or one of three other options saying they weren't sure if it was positive or negative; we use only the positive/negative labels.\n",
-    "We've also altered the dataset to reflect a realistic crowdsourcing pipeline where only a subset of our available training set have recieved crowd labels.\n",
+    "We've also altered the dataset to reflect a realistic crowdsourcing pipeline where only a subset of our available training set has received crowd labels.\n",
     "\n",
     "We will treat each crowdworker's labels as coming from a single labeling function (LF).\n",
-    "This will allow us to learn a weight for how much much to trust the labels from each crowdworker.\n",
+    "This will allow us to learn a weight for how much to trust the labels from each crowdworker.\n",
     "We will also write a few heuristic labeling functions to cover the data points without crowd labels.\n",
     "Snorkel's ability to build high-quality datasets from multiple noisy labeling signals makes it an ideal framework to approach this problem."
    ]
@@ -395,7 +395,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 46%|████▌     | 86/187 [00:00<00:00, 855.44it/s]"
+      " 49%|████▊     | 91/187 [00:00<00:00, 901.54it/s]"
      ]
     },
     {
@@ -403,15 +403,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 95%|█████████▌| 178/187 [00:00<00:00, 871.22it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 187/187 [00:00<00:00, 874.55it/s]"
+      "100%|██████████| 187/187 [00:00<00:00, 927.50it/s]"
      ]
     },
     {
@@ -428,7 +420,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 50/50 [00:00<00:00, 918.63it/s]"
+      "100%|██████████| 50/50 [00:00<00:00, 927.47it/s]"
      ]
     },
     {
@@ -452,7 +444,7 @@
    "metadata": {},
    "source": [
     "Note that because our dev set is so small and our LFs are relatively sparse, many LFs will appear to have zero coverage.\n",
-    "Fortunately, our label model learns weights for LFs based on their coverage on the training set, which is generally much larger."
+    "Fortunately, our label model learns weights for LFs based on their outputs on the training set, which is generally much larger."
    ]
   },
   {
@@ -493,59 +485,59 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>worker_14466721</th>\n",
-       "      <td>46</td>\n",
+       "      <th>worker_6453108</th>\n",
+       "      <td>11</td>\n",
        "      <td>[0, 1]</td>\n",
        "      <td>0.06</td>\n",
        "      <td>0.06</td>\n",
        "      <td>0.04</td>\n",
        "      <td>3</td>\n",
        "      <td>0</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_19715431</th>\n",
-       "      <td>95</td>\n",
-       "      <td>[0, 1]</td>\n",
-       "      <td>0.16</td>\n",
-       "      <td>0.16</td>\n",
-       "      <td>0.14</td>\n",
-       "      <td>8</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>worker_16498372</th>\n",
-       "      <td>58</td>\n",
+       "      <th>worker_18465660</th>\n",
+       "      <td>80</td>\n",
        "      <td>[0, 1]</td>\n",
        "      <td>0.06</td>\n",
        "      <td>0.06</td>\n",
-       "      <td>0.04</td>\n",
+       "      <td>0.06</td>\n",
        "      <td>3</td>\n",
        "      <td>0</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_18112936</th>\n",
-       "      <td>75</td>\n",
-       "      <td>[0, 1]</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>4</td>\n",
+       "      <th>worker_15847995</th>\n",
+       "      <td>56</td>\n",
+       "      <td>[1]</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>0.00</td>\n",
        "      <td>1</td>\n",
-       "      <td>0.8</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_18500901</th>\n",
-       "      <td>81</td>\n",
+       "      <th>worker_15124755</th>\n",
+       "      <td>53</td>\n",
        "      <td>[0, 1]</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>0.04</td>\n",
-       "      <td>2</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>3</td>\n",
        "      <td>0</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>worker_17475684</th>\n",
+       "      <td>68</td>\n",
+       "      <td>[0, 1]</td>\n",
+       "      <td>0.30</td>\n",
+       "      <td>0.30</td>\n",
+       "      <td>0.28</td>\n",
+       "      <td>10</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.666667</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -553,18 +545,18 @@
       ],
       "text/plain": [
        "                  j Polarity  Coverage  Overlaps  Conflicts  Correct  \\\n",
-       "worker_14466721  46  [0, 1]   0.06      0.06      0.04       3         \n",
-       "worker_19715431  95  [0, 1]   0.16      0.16      0.14       8         \n",
-       "worker_16498372  58  [0, 1]   0.06      0.06      0.04       3         \n",
-       "worker_18112936  75  [0, 1]   0.10      0.10      0.10       4         \n",
-       "worker_18500901  81  [0, 1]   0.04      0.04      0.04       2         \n",
+       "worker_6453108   11  [0, 1]   0.06      0.06      0.04       3         \n",
+       "worker_18465660  80  [0, 1]   0.06      0.06      0.06       3         \n",
+       "worker_15847995  56  [1]      0.02      0.02      0.00       1         \n",
+       "worker_15124755  53  [0, 1]   0.06      0.06      0.06       3         \n",
+       "worker_17475684  68  [0, 1]   0.30      0.30      0.28       10        \n",
        "\n",
        "                 Incorrect  Emp. Acc.  \n",
-       "worker_14466721  0          1.0        \n",
-       "worker_19715431  0          1.0        \n",
-       "worker_16498372  0          1.0        \n",
-       "worker_18112936  1          0.8        \n",
-       "worker_18500901  0          1.0        "
+       "worker_6453108   0          1.000000   \n",
+       "worker_18465660  0          1.000000   \n",
+       "worker_15847995  0          1.000000   \n",
+       "worker_15124755  0          1.000000   \n",
+       "worker_17475684  5          0.666667   "
       ]
      },
      "execution_count": 8,
@@ -677,7 +669,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 16%|█▌        | 30/187 [00:00<00:00, 296.34it/s]"
+      " 18%|█▊        | 34/187 [00:00<00:00, 338.15it/s]"
      ]
     },
     {
@@ -685,7 +677,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 47%|████▋     | 88/187 [00:00<00:00, 347.16it/s]"
+      " 51%|█████     | 95/187 [00:00<00:00, 389.26it/s]"
      ]
     },
     {
@@ -693,7 +685,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 79%|███████▊  | 147/187 [00:00<00:00, 395.49it/s]"
+      " 83%|████████▎ | 155/187 [00:00<00:00, 434.66it/s]"
      ]
     },
     {
@@ -701,15 +693,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 99%|█████████▉| 186/187 [00:00<00:00, 390.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 187/187 [00:00<00:00, 455.41it/s]"
+      "100%|██████████| 187/187 [00:00<00:00, 519.91it/s]"
      ]
     },
     {
@@ -726,15 +710,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 98%|█████████▊| 49/50 [00:00<00:00, 488.52it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 50/50 [00:00<00:00, 477.11it/s]"
+      "100%|██████████| 50/50 [00:00<00:00, 572.53it/s]"
      ]
     },
     {
@@ -946,12 +922,10 @@
    ],
    "source": [
     "from snorkel.analysis import metric_score\n",
-    "from snorkel.utils import probs_to_preds\n",
     "\n",
-    "Y_dev_prob = label_model.predict_proba(L_dev)\n",
-    "Y_dev_pred = probs_to_preds(Y_dev_prob)\n",
+    "Y_dev_preds = label_model.predict(L_dev)\n",
     "\n",
-    "acc = metric_score(Y_dev, Y_dev_pred, probs=None, metric=\"accuracy\")\n",
+    "acc = metric_score(Y_dev, Y_dev_preds, probs=None, metric=\"accuracy\")\n",
     "print(f\"LabelModel Accuracy: {acc:.3f}\")"
    ]
   },
@@ -975,7 +949,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Y_train_prob = label_model.predict_proba(L_train)"
+    "Y_train_preds = label_model.predict(L_train)"
    ]
   },
   {
@@ -1051,7 +1025,7 @@
     "from sklearn.linear_model import LogisticRegression\n",
     "\n",
     "sklearn_model = LogisticRegression(solver=\"liblinear\")\n",
-    "sklearn_model.fit(train_vectors, probs_to_preds(Y_train_prob))"
+    "sklearn_model.fit(train_vectors, Y_train_preds)"
    ]
   },
   {
@@ -1086,7 +1060,7 @@
     "\n",
     "In this tutorial, we accomplished the following:\n",
     "* We demonstrated how to combine crowdsourced labels with other programmatic LFs to improve coverage.\n",
-    "* We used the `LabelModel` to learn how to combine inputs from crowdworkers and other LFs to generate high quality probabilistic labels.\n",
+    "* We used the `LabelModel` to combine inputs from crowdworkers and other LFs to generate high quality probabilistic labels.\n",
     "* We used our probabilistic labels to train a classifier for making predictions on new, unseen examples."
    ]
   }

--- a/crowdsourcing/crowdsourcing_tutorial.py
+++ b/crowdsourcing/crowdsourcing_tutorial.py
@@ -1,73 +1,61 @@
 # %% [markdown]
-# # Crowdsourcing tutorial
-# In this tutorial, we'll provide a simple walkthrough of how to use Snorkel alongside crowdsourcing to generate labels for a sentiment analysis task.
-# We have crowdsourced labels for about half of the training dataset.
-# The crowdsourcing labels are of a fairly high quality, but do not cover the entire training dataset, nor are they available for the test set or during inference.
-# To make up for their lack of training set coverage, we combine crowdsourcing labels with heuristic labeling functions to increase the number of training labels we have.
+# # Crowdsourcing Tutorial
+
+# %% [markdown]
+# In this tutorial, we'll provide a simple walkthrough of how to use Snorkel in conjuction with crowdsourcing to create a training set for a sentiment analysis task.
+# We already have crowdsourced labels for about half of the training dataset.
+# The crowdsourced labels are fairly accurate, but do not cover the entire training dataset, nor are they available for the test set or during inference.
+# To make up for their lack of training set coverage, we combine crowdsourced labels with heuristic labeling functions to increase the number of training labels we have.
 # Like most Snorkel labeling pipelines, we'll use the denoised labels to train a deep learning
-# model which can be applied to new, unseen data to automatically make predictions!
+# model which can be applied to new, unseen data to automatically make predictions.
+
+# %% [markdown]
+# ## Dataset Details
+
+# %% [markdown]
+# In this tutorial, we'll use the [Weather Sentiment](https://data.world/crowdflower/weather-sentiment) dataset from Figure Eight.
+# Our goal is to train a classifier that can label new tweets as expressing either a positive or negative sentiment.
 #
-# In this tutorial, we're using the
-# [Weather Sentiment](https://data.world/crowdflower/weather-sentiment)
-# dataset from Figure Eight.
-# Our goal is to label each tweet as either positive or negative so that
-# we can train a language model over the tweets themselves that can be applied
-# to new, unseen data points.
-# Crowd workers were asked to grade the sentiment of a
-# particular tweet relating to the weather. They could say it was positive or
-# negative, or choose one of three other options saying they weren't sure it was
-# positive or negative.
-#
-# The catch is that 20 crowd workers graded each tweet, and in many cases
-# crowd workers assigned conflicting sentiment labels to the same tweet.
+# Crowdworkers were asked to label the sentiment of a particular tweet relating to the weather.
+# The catch is that 20 crowdworkers graded each tweet, and in many cases crowdworkers assigned conflicting sentiment labels to the same tweet.
 # This is a common issue when dealing with crowdsourced labeling workloads.
 #
-# We've also altered the data set to reflect a realistic crowdsourcing pipeline
-# where only a subset of our full training set have recieved crowd labels.
-# Since our objective is to classify tweets as positive or negative, we limited
-# the dataset to tweets that were either positive or negative.
+# Label options were positive, negative, or one of three other options saying they weren't sure if it was positive or negative; we use only the positive/negative labels.
+# We've also altered the dataset to reflect a realistic crowdsourcing pipeline where only a subset of our available training set have recieved crowd labels.
 #
-# We'll encode the crowd labels themselves as labeling functions in order
-# to learn trust weights for each crowd worker, and write a few heuristic
-# labeling functions to cover the data points without crowd labels.
-# Snorkel's ability to build high-quality datasets from multiple noisy labeling
-# signals makes it an ideal framework to approach this problem.
+# We will treat each crowdworker's labels as coming from a single labeling function (LF).
+# This will allow us to learn a weight for how much much to trust the labels from each crowdworker.
+# We will also write a few heuristic labeling functions to cover the data points without crowd labels.
+# Snorkel's ability to build high-quality datasets from multiple noisy labeling signals makes it an ideal framework to approach this problem.
+
+# %% [markdown]
+# ## Loading Crowdsourcing Dataset
 
 # %% [markdown]
 # We start by loading our data which has 287 examples in total.
 # We take 50 for our development set and 50 for our test set.
 # The remaining 187 examples form our training set.
-# This data set is very small, and we're primarily using it for demonstration purposes.
-# In particular, we'd expect to have access to many more unlabeled tweets in order to
-# train a high performance text model.
-# Since the dataset is already small, we skip
-# using a validation set.
-#
-# The labels above have been mapped to integers, which we show here.
-
-# %% [markdown]
-# ## Loading Crowdsourcing Dataset
+# Since the dataset is already small, we skip using a validation set.
+# Note that this very small dataset is primarily used for demonstration purposes here.
+# In a real setting, we would expect to have access to many more unlabeled tweets, which could help us to train a higher quality model.
 
 # %%
 import os
 
+# Make sure we're in the right directory
 if os.path.basename(os.getcwd()) == "snorkel-tutorials":
     os.chdir("crowdsourcing")
 
 # %%
-from data import load_data, answer_mapping
+from data import load_data
 
-crowd_answers, df_train, df_dev, df_test = load_data()
+crowd_labels, df_train, df_dev, df_test = load_data()
 Y_dev = df_dev.sentiment.values
 Y_test = df_test.sentiment.values
 
-print("Answer to int mapping:")
-for k, v in sorted(answer_mapping.items(), key=lambda kv: kv[1]):
-    print(f"{k:<50}{v}")
-
 # %% [markdown]
-# First, let's take a look at our development set to get a sense of
-# what the tweets look like.
+# First, let's take a look at our development set to get a sense of what the tweets look like.  
+# We use the following label convention: 0 = Negative, 1 = Positive.
 
 # %%
 import pandas as pd
@@ -82,56 +70,44 @@ df_dev.head()
 # We'll convert these into labeling functions.
 
 # %%
-crowd_answers.head()
+crowd_labels.head()
 
 # %% [markdown]
 # ## Writing Labeling Functions
-# Each crowd worker can be thought of as a single labeling function,
+# Each crowdworker can be thought of as a single labeling function,
 # as each worker labels a subset of examples,
-# and may have errors or conflicting answers with other workers / labeling functions.
+# and may have errors or conflicting labels with other workers / labeling functions.
 # So we create one labeling function per worker.
 # We'll simply return the label the worker submitted for a given tweet, and abstain
-# if they didn't submit an answer for it.
+# if they didn't submit a label for it.
 
 # %% [markdown]
-# ### Crowd worker labeling functions
+# ### Crowdworker labeling functions
 
 # %%
-labels_by_annotator = crowd_answers.groupby("worker_id")
+labels_by_annotator = crowd_labels.groupby("worker_id")
 worker_dicts = {}
 for worker_id in labels_by_annotator.groups:
-    worker_df = labels_by_annotator.get_group(worker_id)[["answer"]]
-    if len(worker_df) > 10:
-        worker_dicts[worker_id] = dict(zip(worker_df.index, worker_df.answer))
+    worker_df = labels_by_annotator.get_group(worker_id)[["label"]]
+    worker_dicts[worker_id] = dict(zip(worker_df.index, worker_df.label))
 
 print("Number of workers:", len(worker_dicts))
 
 # %%
 from snorkel.labeling import LabelingFunction
 
+ABSTAIN = -1
 
-def f_pos(x, worker_dict):
-    label = worker_dict.get(x.tweet_id)
-    return 1 if label == 1 else -1
+def worker_lf(x, worker_dict):
+    return worker_dict.get(x.tweet_id, ABSTAIN)
 
-
-def f_neg(x, worker_dict):
-    label = worker_dict.get(x.tweet_id)
-    return 0 if label == 0 else -1
-
-
-def get_worker_labeling_function(worker_id, f):
+def make_worker_lf(worker_id):
     worker_dict = worker_dicts[worker_id]
-    name = f"worker_{worker_id}_{f.__name__}"
-    return LabelingFunction(name, f=f, resources={"worker_dict": worker_dict})
+    name = f"worker_{worker_id}"
+    return LabelingFunction(name, f=worker_lf, resources={"worker_dict": worker_dict})
 
 
-worker_lfs_pos = [
-    get_worker_labeling_function(worker_id, f_pos) for worker_id in worker_dicts
-]
-worker_lfs_neg = [
-    get_worker_labeling_function(worker_id, f_neg) for worker_id in worker_dicts
-]
+worker_lfs = [make_worker_lf(worker_id) for worker_id in worker_dicts]
 
 # %% [markdown]
 # Let's take a quick look at how well they do on the development set.
@@ -139,29 +115,31 @@ worker_lfs_neg = [
 # %%
 from snorkel.labeling import PandasLFApplier
 
-lfs = worker_lfs_pos + worker_lfs_neg
-
-applier = PandasLFApplier(lfs)
+applier = PandasLFApplier(worker_lfs)
 L_train = applier.apply(df_train)
 L_dev = applier.apply(df_dev)
+
+# %% [markdown]
+# Note that because our dev set is so small and our LFs are relatively sparse, many LFs will appear to have zero coverage.
+# Fortunately, our label model learns weights for LFs based on their coverage on the training set, which is generally much larger.
 
 # %%
 from snorkel.labeling import LFAnalysis
 
-LFAnalysis(L_dev, lfs).lf_summary(Y_dev).head()
+LFAnalysis(L_dev, worker_lfs).lf_summary(Y_dev).sample(5)
 
 # %% [markdown]
-# So the crowd labels are quite good! But how much of our dev and training
+# So the crowd labels in general are quite good! But how much of our dev and training
 # sets do they cover?
 
 # %%
-print("Training set coverage:", LFAnalysis(L_train).label_coverage())
-print("Dev set coverage:", LFAnalysis(L_dev).label_coverage())
+print(f"Training set coverage: {LFAnalysis(L_train).label_coverage(): 0.3f}")
+print(f"Dev set coverage: {LFAnalysis(L_dev).label_coverage(): 0.3f}")
 
 # %% [markdown]
 # ### Additional labeling functions
 #
-# To improve coverage of the training set, we can mix the crowd worker labeling functions with labeling
+# To improve coverage of the training set, we can mix the crowdworker labeling functions with labeling
 # functions of other types.
 # For example, we can use [TextBlob](https://textblob.readthedocs.io/en/dev/index.html), a tool that provides a pretrained sentiment analyzer. We run TextBlob on our tweets and create some simple LFs that threshold its polarity score, similar to what we did in the spam_tutorial.
 
@@ -171,14 +149,12 @@ from snorkel.preprocess import preprocessor
 from textblob import TextBlob
 
 
-@preprocessor()
+@preprocessor(memoize=True)
 def textblob_polarity(x):
     scores = TextBlob(x.tweet_text)
     x.polarity = scores.polarity
     return x
 
-
-textblob_polarity.memoize = True
 
 # Label high polarity tweets as positive.
 @labeling_function(pre=[textblob_polarity])
@@ -203,7 +179,7 @@ def polarity_negative_2(x):
 
 # %%
 text_lfs = [polarity_positive, polarity_negative, polarity_negative_2]
-lfs = text_lfs + worker_lfs_pos + worker_lfs_neg
+lfs = text_lfs + worker_lfs
 
 applier = PandasLFApplier(lfs)
 L_train = applier.apply(df_train)
@@ -219,8 +195,8 @@ LFAnalysis(L_dev, lfs).lf_summary(Y_dev).head()
 # to denoise and combine them.
 
 # %%
-print("Training set coverage:", LFAnalysis(L_train).label_coverage())
-print("Dev set coverage:", LFAnalysis(L_dev).label_coverage())
+print(f"Training set coverage: {LFAnalysis(L_train).label_coverage(): 0.3f}")
+print(f"Dev set coverage: {LFAnalysis(L_dev).label_coverage(): 0.3f}")
 
 # %% [markdown]
 # ## Train LabelModel And Generate Probabilistic Labels
@@ -246,16 +222,14 @@ acc = metric_score(Y_dev, Y_dev_pred, probs=None, metric="accuracy")
 print(f"LabelModel Accuracy: {acc:.3f}")
 
 # %% [markdown]
-# Look at that, we get very high accuracy on the development set.
-# This is due to the abundance of high quality crowd worker labels.
+# We see that we get very high accuracy on the development set.
+# This is due to the abundance of high quality crowdworker labels.
 # **Since we don't have these high quality crowdsourcing labels for the
 # test set or new incoming examples, we can't use the LabelModel reliably
 # at inference time.**
 # In order to run inference on new incoming examples, we need to train a
 # discriminative model over the tweets themselves.
-# Let's generate a set of probabilistic labels for the training set.
-
-# %%
+# Let's generate a set of probabilistic labels for that training set.
 
 # %%
 Y_train_prob = label_model.predict_proba(L_train)
@@ -265,7 +239,9 @@ Y_train_prob = label_model.predict_proba(L_train)
 
 # %% [markdown]
 # ### Getting features from BERT
-# Since we have very limited training data, we cannot train a complex model like an LSTM with a lot of parameters. Instead, we use a pre-trained model, [BERT](https://github.com/google-research/bert), to generate embeddings for each our tweets, and treat the embedding values as features.
+# Since we have very limited training data, we cannot train a complex model like an LSTM with a lot of parameters. 
+# Instead, we use a pre-trained model, [BERT](https://github.com/google-research/bert), to generate embeddings for each our tweets, and treat the embedding values as features.
+# This may take 5-10 minutes on a CPU, as the BERT model is very large.
 
 # %%
 import numpy as np
@@ -295,15 +271,16 @@ from sklearn.linear_model import LogisticRegression
 sklearn_model = LogisticRegression(solver="liblinear")
 sklearn_model.fit(train_vectors, probs_to_preds(Y_train_prob))
 
+# %%
 print(f"Accuracy of trained model: {sklearn_model.score(test_vectors, Y_test)}")
 
 # %% [markdown]
-# We now have a model with accuracy not much lower than the LabelModel, but with the advantage of being faster and cheaper than crowdsourcing, and applicable to all future examples.
+# We now have a trained model that can be applied to future examples without requiring crowdsourced labels, and with accuracy not much lower than the `LabelModel` that _does_ have access to crowdsourced labels! 
 
 # %% [markdown]
 # ## Summary
 #
 # In this tutorial, we accomplished the following:
-# * We showed how Snorkel can handle crowdsourced labels, combining them with other programmatic LFs to improve coverage.
-# * We showed how the LabelModel learns to combine inputs from crowd workers and other LFs by appropriately weighting them to generate high quality probabilistic labels.
-# * We showed that a classifier trained on the combined labels can achieve a fairly high accuracy while also generalizing to new, unseen examples.
+# * We demonstrated how to combine crowdsourced labels with other programmatic LFs to improve coverage.
+# * We used the `LabelModel` to learn how to combine inputs from crowdworkers and other LFs to generate high quality probabilistic labels.
+# * We used our probabilistic labels to train a classifier for making predictions on new, unseen examples.

--- a/crowdsourcing/crowdsourcing_tutorial.py
+++ b/crowdsourcing/crowdsourcing_tutorial.py
@@ -54,7 +54,7 @@ Y_dev = df_dev.sentiment.values
 Y_test = df_test.sentiment.values
 
 # %% [markdown]
-# First, let's take a look at our development set to get a sense of what the tweets look like.  
+# First, let's take a look at our development set to get a sense of what the tweets look like.
 # We use the following label convention: 0 = Negative, 1 = Positive.
 
 # %%
@@ -98,8 +98,10 @@ from snorkel.labeling import LabelingFunction
 
 ABSTAIN = -1
 
+
 def worker_lf(x, worker_dict):
     return worker_dict.get(x.tweet_id, ABSTAIN)
+
 
 def make_worker_lf(worker_id):
     worker_dict = worker_dicts[worker_id]
@@ -239,7 +241,7 @@ Y_train_prob = label_model.predict_proba(L_train)
 
 # %% [markdown]
 # ### Getting features from BERT
-# Since we have very limited training data, we cannot train a complex model like an LSTM with a lot of parameters. 
+# Since we have very limited training data, we cannot train a complex model like an LSTM with a lot of parameters.
 # Instead, we use a pre-trained model, [BERT](https://github.com/google-research/bert), to generate embeddings for each our tweets, and treat the embedding values as features.
 # This may take 5-10 minutes on a CPU, as the BERT model is very large.
 
@@ -275,7 +277,7 @@ sklearn_model.fit(train_vectors, probs_to_preds(Y_train_prob))
 print(f"Accuracy of trained model: {sklearn_model.score(test_vectors, Y_test)}")
 
 # %% [markdown]
-# We now have a trained model that can be applied to future examples without requiring crowdsourced labels, and with accuracy not much lower than the `LabelModel` that _does_ have access to crowdsourced labels! 
+# We now have a trained model that can be applied to future examples without requiring crowdsourced labels, and with accuracy not much lower than the `LabelModel` that _does_ have access to crowdsourced labels!
 
 # %% [markdown]
 # ## Summary

--- a/crowdsourcing/crowdsourcing_tutorial.py
+++ b/crowdsourcing/crowdsourcing_tutorial.py
@@ -2,7 +2,7 @@
 # # Crowdsourcing Tutorial
 
 # %% [markdown]
-# In this tutorial, we'll provide a simple walkthrough of how to use Snorkel in conjuction with crowdsourcing to create a training set for a sentiment analysis task.
+# In this tutorial, we'll provide a simple walkthrough of how to use Snorkel in conjunction with crowdsourcing to create a training set for a sentiment analysis task.
 # We already have crowdsourced labels for about half of the training dataset.
 # The crowdsourced labels are fairly accurate, but do not cover the entire training dataset, nor are they available for the test set or during inference.
 # To make up for their lack of training set coverage, we combine crowdsourced labels with heuristic labeling functions to increase the number of training labels we have.
@@ -21,10 +21,10 @@
 # This is a common issue when dealing with crowdsourced labeling workloads.
 #
 # Label options were positive, negative, or one of three other options saying they weren't sure if it was positive or negative; we use only the positive/negative labels.
-# We've also altered the dataset to reflect a realistic crowdsourcing pipeline where only a subset of our available training set have recieved crowd labels.
+# We've also altered the dataset to reflect a realistic crowdsourcing pipeline where only a subset of our available training set has received crowd labels.
 #
 # We will treat each crowdworker's labels as coming from a single labeling function (LF).
-# This will allow us to learn a weight for how much much to trust the labels from each crowdworker.
+# This will allow us to learn a weight for how much to trust the labels from each crowdworker.
 # We will also write a few heuristic labeling functions to cover the data points without crowd labels.
 # Snorkel's ability to build high-quality datasets from multiple noisy labeling signals makes it an ideal framework to approach this problem.
 
@@ -123,7 +123,7 @@ L_dev = applier.apply(df_dev)
 
 # %% [markdown]
 # Note that because our dev set is so small and our LFs are relatively sparse, many LFs will appear to have zero coverage.
-# Fortunately, our label model learns weights for LFs based on their coverage on the training set, which is generally much larger.
+# Fortunately, our label model learns weights for LFs based on their outputs on the training set, which is generally much larger.
 
 # %%
 from snorkel.labeling import LFAnalysis
@@ -215,12 +215,10 @@ label_model.fit(L_train, n_epochs=100, seed=123, log_freq=20, l2=0.1, lr=0.01)
 
 # %%
 from snorkel.analysis import metric_score
-from snorkel.utils import probs_to_preds
 
-Y_dev_prob = label_model.predict_proba(L_dev)
-Y_dev_pred = probs_to_preds(Y_dev_prob)
+Y_dev_preds = label_model.predict(L_dev)
 
-acc = metric_score(Y_dev, Y_dev_pred, probs=None, metric="accuracy")
+acc = metric_score(Y_dev, Y_dev_preds, probs=None, metric="accuracy")
 print(f"LabelModel Accuracy: {acc:.3f}")
 
 # %% [markdown]
@@ -234,7 +232,7 @@ print(f"LabelModel Accuracy: {acc:.3f}")
 # Let's generate a set of probabilistic labels for that training set.
 
 # %%
-Y_train_prob = label_model.predict_proba(L_train)
+Y_train_preds = label_model.predict(L_train)
 
 # %% [markdown]
 # ## Use Soft Labels to Train End Model
@@ -271,7 +269,7 @@ test_vectors = np.array(list(df_test.tweet_text.apply(encode_text).values))
 from sklearn.linear_model import LogisticRegression
 
 sklearn_model = LogisticRegression(solver="liblinear")
-sklearn_model.fit(train_vectors, probs_to_preds(Y_train_prob))
+sklearn_model.fit(train_vectors, Y_train_preds)
 
 # %%
 print(f"Accuracy of trained model: {sklearn_model.score(test_vectors, Y_test)}")
@@ -284,5 +282,5 @@ print(f"Accuracy of trained model: {sklearn_model.score(test_vectors, Y_test)}")
 #
 # In this tutorial, we accomplished the following:
 # * We demonstrated how to combine crowdsourced labels with other programmatic LFs to improve coverage.
-# * We used the `LabelModel` to learn how to combine inputs from crowdworkers and other LFs to generate high quality probabilistic labels.
+# * We used the `LabelModel` to combine inputs from crowdworkers and other LFs to generate high quality probabilistic labels.
 # * We used our probabilistic labels to train a classifier for making predictions on new, unseen examples.

--- a/crowdsourcing/data.py
+++ b/crowdsourcing/data.py
@@ -5,12 +5,12 @@ from typing import Tuple
 import pandas as pd
 
 
-answer_mapping = {
-    "I can't tell": -1,
+LABEL_MAPPING = {
     "Negative": 0,
     "Positive": 1,
+    "I can't tell": 2,
     "Neutral / author is just sharing information": 2,
-    "Tweet not related to weather condition": 3,
+    "Tweet not related to weather condition": 2,
 }
 
 
@@ -34,27 +34,30 @@ def load_data() -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]
     ]
     labeled = labeled.sample(frac=1, random_state=123)  # Shuffle items.
 
-    crowd_answers = pd.read_csv("data/weather-non-agg-DFE.csv")
-    # Keep only the tweets with available groundtruth.
-    crowd_answers = crowd_answers.join(
+    crowd_labels = pd.read_csv("data/weather-non-agg-DFE.csv")
+    # Keep only the tweets with available ground truth.
+    crowd_labels = crowd_labels.join(
         labeled, on=["tweet_id"], lsuffix=".raw", rsuffix=".gold", how="inner"
     )
-    crowd_answers = crowd_answers[["tweet_id", "worker_id", "emotion"]]
-    crowd_answers.emotion = crowd_answers.emotion.map(answer_mapping)
-    crowd_answers = crowd_answers.rename(columns=dict(emotion="answer"))
-    crowd_answers = crowd_answers.set_index("tweet_id")
+    crowd_labels = crowd_labels[["tweet_id", "worker_id", "emotion"]]
+    crowd_labels.emotion = crowd_labels.emotion.map(LABEL_MAPPING)
+    crowd_labels = crowd_labels.rename(columns=dict(emotion="label"))
+    crowd_labels = crowd_labels.set_index("tweet_id")
+    crowd_labels = crowd_labels[crowd_labels["label"] != 2]
 
     df_dev = labeled[:50]
     df_dev = df_dev[["tweet_id", "tweet_text", "sentiment"]]
-    df_dev.sentiment = df_dev.sentiment.map(answer_mapping).values
-    crowd_answers = crowd_answers.drop(df_dev[: int(len(df_dev) / 2)].tweet_id)
+    df_dev.sentiment = df_dev.sentiment.map(LABEL_MAPPING).values
+    # Remove half the labels
+    crowd_labels = crowd_labels.drop(df_dev[: int(len(df_dev) / 2)].tweet_id)
 
     df_test = labeled[50:100]
     df_test = df_test[["tweet_id", "tweet_text", "sentiment"]]
-    df_test.sentiment = df_test.sentiment.map(answer_mapping).values
-    crowd_answers = crowd_answers.drop(df_test.tweet_id)
+    df_test.sentiment = df_test.sentiment.map(LABEL_MAPPING).values
+    crowd_labels = crowd_labels.drop(df_test.tweet_id)
 
     df_train = labeled[100:][["tweet_id", "tweet_text"]]
-    crowd_answers = crowd_answers.drop(df_train[: int(len(df_train) / 2)].tweet_id)
+    # Remove half the labels
+    crowd_labels = crowd_labels.drop(df_train[: int(len(df_train) / 2)].tweet_id)
 
-    return crowd_answers, df_train, df_dev, df_test
+    return crowd_labels, df_train, df_dev, df_test


### PR DESCRIPTION
Made a pass over the Crowdsourcing Tutorial.
- Mostly local edits
- A couple renamings ("answers" -> "labels", "crowd worker" -> "crowdworkers", etc.)
- Simplify to one LF per crowdworker instead of splitting in 2

Some markdown diffs will appear larger than they are where I split on sentence boundaries instead of characters for clearer diffs in the future.

**Test plan:**
`tox -e crowsourcing`