### PR TITLE
[EASY] Add links to RTD in multitask tutorial

### DIFF
--- a/multitask/multitask_tutorial.ipynb
+++ b/multitask/multitask_tutorial.ipynb
@@ -312,8 +312,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A dictionary containing the outputs of all operations will then go into a `loss_func()` to calculate the loss (e.g., cross-entropy) during training or an `output_func()` (e.g., softmax) to convert the logits into a prediction.\n",
-    "Both of these functions accept as an argument the name of the operation whose output they should use to calculate their respective values; in this case, that will be the `circle_head` operation.\n",
+    "A dictionary containing the outputs of all operations will then go into a loss function to calculate the loss (e.g., cross-entropy) during training or an output function (e.g., softmax) to convert the logits into a prediction.\n",
+    "Both of these functions ([cross_entropy_from_outputs](https://snorkel.readthedocs.io/en/redux/packages/_autosummary/classification/snorkel.classification.cross_entropy_from_outputs.html#snorkel.classification.cross_entropy_from_outputs) and [softmax_from_outputs](https://snorkel.readthedocs.io/en/redux/packages/_autosummary/classification/snorkel.classification.cross_entropy_with_probs_from_outputs.html#snorkel.classification.cross_entropy_with_probs_from_outputs)) accept as an argument the name of the operation whose output they should use to calculate their respective values.\n",
+    "In this case, that will be the `circle_head` operation.\n",
     "We indicate that here with the `partial` helper method, which can set the value of that keyword argument before the function is actually called.\n",
     "(As you'll see below, for common classification tasks, the default values for these arguments often suffice).\n",
     "\n",

--- a/multitask/multitask_tutorial.py
+++ b/multitask/multitask_tutorial.py
@@ -178,8 +178,8 @@ op2 = Operation(
 task_flow = [op1, op2]
 
 # %% [markdown]
-# A dictionary containing the outputs of all operations will then go into a `loss_func()` to calculate the loss (e.g., cross-entropy) during training or an `output_func()` (e.g., softmax) to convert the logits into a prediction.
-# Both of these functions accept as an argument the name of the operation whose output they should use to calculate their respective values; in this case, that will be the `circle_head` operation.
+# A dictionary containing the outputs of all operations will then go into a loss function to calculate the loss (e.g., cross-entropy) during training or an output function (e.g., softmax) to convert the logits into a prediction.
+# Both of these functions ([cross_entropy_from_outputs](https://snorkel.readthedocs.io/en/redux/packages/_autosummary/classification/snorkel.classification.cross_entropy_from_outputs.html#snorkel.classification.cross_entropy_from_outputs) and [softmax_from_outputs](https://snorkel.readthedocs.io/en/redux/packages/_autosummary/classification/snorkel.classification.cross_entropy_with_probs_from_outputs.html#snorkel.classification.cross_entropy_with_probs_from_outputs)) accept as an argument the name of the operation whose output they should use to calculate their respective values; in this case, that will be the `circle_head` operation.
 # We indicate that here with the `partial` helper method, which can set the value of that keyword argument before the function is actually called.
 # (As you'll see below, for common classification tasks, the default values for these arguments often suffice).
 #

--- a/multitask/multitask_tutorial.py
+++ b/multitask/multitask_tutorial.py
@@ -179,7 +179,8 @@ task_flow = [op1, op2]
 
 # %% [markdown]
 # A dictionary containing the outputs of all operations will then go into a loss function to calculate the loss (e.g., cross-entropy) during training or an output function (e.g., softmax) to convert the logits into a prediction.
-# Both of these functions ([cross_entropy_from_outputs](https://snorkel.readthedocs.io/en/redux/packages/_autosummary/classification/snorkel.classification.cross_entropy_from_outputs.html#snorkel.classification.cross_entropy_from_outputs) and [softmax_from_outputs](https://snorkel.readthedocs.io/en/redux/packages/_autosummary/classification/snorkel.classification.cross_entropy_with_probs_from_outputs.html#snorkel.classification.cross_entropy_with_probs_from_outputs)) accept as an argument the name of the operation whose output they should use to calculate their respective values; in this case, that will be the `circle_head` operation.
+# Both of these functions ([cross_entropy_from_outputs](https://snorkel.readthedocs.io/en/redux/packages/_autosummary/classification/snorkel.classification.cross_entropy_from_outputs.html#snorkel.classification.cross_entropy_from_outputs) and [softmax_from_outputs](https://snorkel.readthedocs.io/en/redux/packages/_autosummary/classification/snorkel.classification.cross_entropy_with_probs_from_outputs.html#snorkel.classification.cross_entropy_with_probs_from_outputs)) accept as an argument the name of the operation whose output they should use to calculate their respective values.
+# In this case, that will be the `circle_head` operation.
 # We indicate that here with the `partial` helper method, which can set the value of that keyword argument before the function is actually called.
 # (As you'll see below, for common classification tasks, the default values for these arguments often suffice).
 #


### PR DESCRIPTION
With updated RTD, now adding links for two methods in multitask tutorial.

**Test plan:**
Links work (all refs to `redux` will be replaced with `master` in one fell swoop at a later time)