### PR TITLE
Add markdown build mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,24 @@
     * Run `tox -e my_tutorial_dir -- sync` to generate a notebook version from the Python script version. Run this command to update when changes are made to the tutorial script.
     * Run `tox -e my_tutorial_dir -- sync --py` to generate a Python script version from the notebook version. Run this command to update when changes are made to the tutorial notebook.
 6. Run `tox -e my_tutorial_dir` to test out your tutorial. This is also the test that Travis CI will use to check compliance before merges.
+
+## Rendering tutorials as Markdown
+
+In order to display tutorials as webpages, we convert the `.ipynb` versions to Markdown.
+This is again done with `tox`:
+
+```bash
+tox -e my_tutorial -- markdown
+```
+
+This will create a Markdown file under the `build` directory corresponding to the notebook.
+You can exclude cell outputs by using the `--exclude-output` flag.
+Additionally, you can prevent cells from being rendered in Markdown by adding `{"tag": ["md-exclude"]}`
+to the cell header in the `.py` file.
+For example:
+
+```python
+# %% {"tag": ["md-exclude"]}
+command.do_not_show()
+this_line.will_not_appear()
+```

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -204,13 +204,13 @@ def test(tutorial_dir: str) -> None:
 @cli.command()
 @click.argument("tutorial_dir")
 @click.option("--exclude-output", is_flag=True)
-@click.option("--exclude-tags", multiple=True)
+@click.option("--exclude-tag", multiple=True)
 def markdown(
-    tutorial_dir: str, exclude_output: bool, exclude_tags: Optional[List[str]]
+    tutorial_dir: str, exclude_output: bool, exclude_tag: Optional[List[str]]
 ) -> None:
     build_dir = os.path.abspath(os.path.join(tutorial_dir, "..", "build"))
     for notebook in get_notebooks(tutorial_dir):
-        build_markdown_notebook(notebook, build_dir, exclude_output, exclude_tags)
+        build_markdown_notebook(notebook, build_dir, exclude_output, exclude_tag)
 
 
 @cli.command()


### PR DESCRIPTION
For the getting started tutorial:

```
tox -e getting_started -- markdown --exclude-output
```

we can bake in per-tutorial default args when we add to deploy.

adding the md-exclude tag in py:percent will prevent cells from showing up in md:

```python
# %% {"tags": ["md-exclude"]}
os.setup_commandz()
a = 1
```

**Test plan**
Tested locally with and with out tags/output