### PR TITLE
Listen to deprecation warning

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -169,7 +169,7 @@ def check_links(script_path: str) -> None:
         except urllib.error.HTTPError as e:
             raise ValueError(f"Bad link [{url}] found in {script_path}: {e}")
         except Exception as e:
-            logging.warn(
+            logging.warning(
                 f"SKIPPING: Could not access [{url}] found in {script_path}: {e}"
             )
 


### PR DESCRIPTION
Deprecation warning says to use logging.warning instead of logging.warn.

**Test plan:**
checked locally that logging.warn() prints deprecation warning and logging.warning() does not (but both log the message)