### PR TITLE
Make syncing and testing faster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ For example, if you use `pip`, and want to work on the `spam` tutorial:
 
 ```bash
 python3 -m pip install -U 'tox>=3.13.0,<4.0.0'
-pip3 install --upgrade virtualenv
+python3 -m pip install --upgrade virtualenv
 virtualenv -p python3 .env
 source .env/bin/activate
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,9 @@ Once you've worked out details with the maintainers, follow these general steps:
 
 1. Make your changes to the source files
     * For notebook-based tutorials, we recommend making changes to the `.py` version
-    then syncing changes with `tox -e my_tutorial_dir -- sync`.
+    then syncing changes with `tox -e my_tutorial_dir -- sync`. Alternatively, if
+    you have already run all the cells in your browser, you can select
+    File &rarr; Jupytext &rarr; Pair Notebook with Percept Script to save the ipynb.
     * For script-based tutorials, just make the changes as you normally would.
 1. [Test your changes locally](#testing-changes-locally)
 1. Submit a PR!
@@ -69,7 +71,8 @@ Once you've worked out details with the maintainers, follow these general steps:
 Also add the command name to `envlist`.
 1. Write your tutorial!
     * For notebook-based tutorials, write your tutorial either as a Python script (e.g. `my_tutorial_dir/my_tutorial.py`) in [Jupytext percent format](https://gist.github.com/mwouts/91f3e1262871cdaa6d35394cd14f9bdc) or a Jupyter notebook.
-        * Run `tox -e my_tutorial_dir -- sync` to generate a notebook version from the Python script version. Run this command to update when changes are made to the tutorial script.
+        * Run `tox -e my_tutorial_dir -- sync` to generate a notebook version from the Python script version
+          (or if you have run all cells, select File &rarr; Jupytext &rarr; Pair Notebook with Percept Script). Do this to update the notebook whenever changes are made to the tutorial script.
         * Run `tox -e my_tutorial_dir -- sync --py` to generate a Python script version from the notebook version. Run this command to update when changes are made to the tutorial notebook.
     * For script-based tutorials, write your tutoral as a Python script.
 1. [Test your changes locally](#testing-changes-locally)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Once you've worked out details with the maintainers, follow these general steps:
     * For notebook-based tutorials, we recommend making changes to the `.py` version
     then syncing changes with `tox -e my_tutorial_dir -- sync`. Alternatively, if
     you have already run all the cells in your browser, you can select
-    File &rarr; Jupytext &rarr; Pair Notebook with Percept Script to save the ipynb.
+    `File` &rarr; `Jupytext` &rarr; `Pair Notebook with Percept Script` to save the ipynb.
     * For script-based tutorials, just make the changes as you normally would.
 1. [Test your changes locally](#testing-changes-locally)
 1. Submit a PR!
@@ -72,7 +72,8 @@ Also add the command name to `envlist`.
 1. Write your tutorial!
     * For notebook-based tutorials, write your tutorial either as a Python script (e.g. `my_tutorial_dir/my_tutorial.py`) in [Jupytext percent format](https://gist.github.com/mwouts/91f3e1262871cdaa6d35394cd14f9bdc) or a Jupyter notebook.
         * Run `tox -e my_tutorial_dir -- sync` to generate a notebook version from the Python script version
-          (or if you have run all cells, select File &rarr; Jupytext &rarr; Pair Notebook with Percept Script). Do this to update the notebook whenever changes are made to the tutorial script.
+          (or if you have run all cells, you can select `File` &rarr; `Jupytext` &rarr; `Pair Notebook with Percept Script`).
+          Do this to update the notebook whenever changes are made to the tutorial script.
         * Run `tox -e my_tutorial_dir -- sync --py` to generate a Python script version from the notebook version. Run this command to update when changes are made to the tutorial notebook.
     * For script-based tutorials, write your tutoral as a Python script.
 1. [Test your changes locally](#testing-changes-locally)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,13 @@ Once you've worked out details with the maintainers, follow these general steps:
 
 1. Make your changes to the source files
     * For notebook-based tutorials, we recommend making changes to the `.py` version
-    then syncing changes with `tox -e my_tutorial_dir -- sync`. Alternatively, if
-    you have already run all the cells in your browser, you can select
-    `File` &rarr; `Jupytext` &rarr; `Pair Notebook with Percept Script` to save the ipynb.
+    then syncing changes with `tox -e my_tutorial_dir -- sync`.
+    Alternatively, if you have already run all the cells in your browser, you can select
+    `File` &rarr; `Jupytext` &rarr; `Pair Notebook with percent Script` to save the
+    outputs directly to the notebook version.
+    After saving, unpair the notebook with
+    `File` &rarr; `Jupytext` &rarr; `Unpair notebook` so jupyter does not
+    keep updating the notebook when all cells haven't been run.
     * For script-based tutorials, just make the changes as you normally would.
 1. [Test your changes locally](#testing-changes-locally)
 1. Submit a PR!
@@ -72,7 +76,11 @@ Also add the command name to `envlist`.
 1. Write your tutorial!
     * For notebook-based tutorials, write your tutorial either as a Python script (e.g. `my_tutorial_dir/my_tutorial.py`) in [Jupytext percent format](https://gist.github.com/mwouts/91f3e1262871cdaa6d35394cd14f9bdc) or a Jupyter notebook.
         * Run `tox -e my_tutorial_dir -- sync` to generate a notebook version from the Python script version
-          (or if you have run all cells, you can select `File` &rarr; `Jupytext` &rarr; `Pair Notebook with Percept Script`).
+          (or if you have run all cells, you can select
+          `File` &rarr; `Jupytext` &rarr; `Pair Notebook with percent Script` to
+          save the outputs directly to the notebook version, and then unpair it
+          with `File` &rarr; `Jupytext` &rarr; `Unpair notebook` so jupyter does not
+          keep updating the notebook when all cells haven't been run).
           Do this to update the notebook whenever changes are made to the tutorial script.
         * Run `tox -e my_tutorial_dir -- sync --py` to generate a Python script version from the notebook version. Run this command to update when changes are made to the tutorial notebook.
     * For script-based tutorials, write your tutoral as a Python script.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,8 @@ python3 -m pip install --upgrade virtualenv
 virtualenv -p python3 .env
 source .env/bin/activate
 
-pip3 install -r requirements.txt
-pip3 install -r spam/requirements.txt  # Change based on tutorial.
+python3 -m pip install -r requirements.txt
+python3 -m pip install -r spam/requirements.txt  # Change based on tutorial.
 ```
 
 Start jupyter from the virtualenv to make sure the kernel has all the required dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,20 @@ We default to using notebook-based tutorials.
 
 ## Dev Setup
 
-The only required dev setup is installing [`tox`](https://tox.readthedocs.io).
-For example, if you use `pip`:
+For dev setup, you  will need to install [`tox`](https://tox.readthedocs.io), and set up a virtualenv with all the requirements.
+For example, if you use `pip`, and want to work on the `spam` tutorial:
 
 ```bash
 python3 -m pip install -U 'tox>=3.13.0,<4.0.0'
+pip3 install --upgrade virtualenv
+virtualenv -p python3 .env
+source .env/bin/activate
+
+pip3 install -r requirements.txt
+pip3 install -r spam/requirements.txt  # Change based on tutorial.
 ```
+
+Start jupyter from the virtualenv to make sure the kernel has all the required dependencies.
 
 ## Making Changes to an Existing Tutorial
 

--- a/recsys/utils.py
+++ b/recsys/utils.py
@@ -13,7 +13,7 @@ import pandas as pd
 from sklearn.model_selection import train_test_split
 from tensorflow.keras import backend as K
 
-IS_TRAVIS = os.environ.get("TRAVIS") == "true"
+IS_TEST = os.environ.get("TRAVIS") == "true" or os.environ.get("IS_TEST") == "true"
 
 YA_BOOKS_URL = "https://drive.google.com/uc?id=1gH7dG4yQzZykTpbHYsrw2nFknjUm0Mol"
 YA_INTERACTIONS_URL = "https://drive.google.com/uc?id=1NNX7SWcKahezLFNyiW88QFPAqOAYP5qg"
@@ -63,7 +63,7 @@ def load_small_sample():
 def maybe_download_files(data_dir: str = "data") -> None:
     if not os.path.exists(data_dir):
         os.makedirs(data_dir, exist_ok=True)
-        if IS_TRAVIS:
+        if IS_TEST:
             # Sample data pickle
             gdown.download(SMALL_DATA_URL, output=SAMPLE_DATA, quiet=None)
         else:
@@ -212,7 +212,7 @@ def split_data(user_idxs, data: pd.DataFrame) -> Tuple[pd.DataFrame, ...]:
 def download_and_process_data() -> Tuple[Tuple[pd.DataFrame, ...], pd.DataFrame]:
     logging.info("Downloading raw data")
     maybe_download_files()
-    if IS_TRAVIS:
+    if IS_TEST:
         return load_small_sample()
     logging.info("Processing book data")
     df_books, book_id_to_idx = process_books_data()
@@ -262,4 +262,4 @@ def f1_batch(y_true: np.ndarray, y_pred: np.ndarray) -> float:
 
 
 def get_n_epochs() -> int:
-    return 2 if IS_TRAVIS else 30
+    return 2 if IS_TEST else 30

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -239,6 +239,7 @@ def get_scripts(tutorial_dir: str) -> List[Notebook]:
 
 def check_notebook(notebook: Notebook) -> None:
     assert os.path.exists(notebook.py), f"No file {notebook.py}"
+    os.environ["IS_TEST"] = "true"
     logging.info(f"Checking links in [{notebook.py}]")
     check_links(notebook.py)
     notebook_actual = jupytext.read(notebook.ipynb, fmt=dict(extension="ipynb"))
@@ -246,6 +247,14 @@ def check_notebook(notebook: Notebook) -> None:
         logging.info(f"Executing notebook [{notebook.py}]")
         call_jupytext(notebook, f.name, to_ipynb=True)
         notebook_expected = jupytext.read(f.name, fmt=dict(extension="ipynb"))
+        # notebook_metadata_filter gets flipped during execution. Remove it to ensure
+        # all metadata is tested.
+        notebook_actual.metadata.get("jupytext", {}).pop(
+            "notebook_metadata_filter", None
+        )
+        notebook_expected.metadata.get("jupytext", {}).pop(
+            "notebook_metadata_filter", None
+        )
         compare_notebooks(notebook_actual, notebook_expected)
 
 

--- a/spouse/utils.py
+++ b/spouse/utils.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import pandas as pd
 
-IS_TRAVIS = os.environ.get("TRAVIS") == "true"
+IS_TEST = os.environ.get("TRAVIS") == "true" or os.environ.get("IS_TEST") == "true"
 
 
 def load_data() -> Tuple[
@@ -30,7 +30,7 @@ def load_data() -> Tuple[
 
     with open(os.path.join("data", "train_data.pkl"), "rb") as f:
         df_train = pickle.load(f)
-        if IS_TRAVIS:
+        if IS_TEST:
             # Reduce train set size to speed up travis.
             df_train = df_train.iloc[:2000]
 
@@ -45,4 +45,4 @@ def load_data() -> Tuple[
 
 
 def get_n_epochs() -> int:
-    return 3 if IS_TRAVIS else 30
+    return 3 if IS_TEST else 30

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     drybell: -rdrybell/requirements.txt
 passenv =
     JAVA_HOME
+    IS_TEST
     TRAVIS
 commands_pre = 
     drybell: python -m spacy download en_core_web_sm

--- a/visual_relation/visual_relation_tutorial.ipynb
+++ b/visual_relation/visual_relation_tutorial.ipynb
@@ -75,8 +75,8 @@
     "\n",
     "# setting sample=False will take ~3 hours to run (downloads full VRD dataset)\n",
     "sample = True\n",
-    "is_travis = os.environ.get(\"TRAVIS\") == \"true\"\n",
-    "df_train, df_valid, df_test = load_vrd_data(sample, is_travis)\n",
+    "is_test = os.environ.get(\"TRAVIS\") == \"true\" or os.environ.get(\"IS_TEST\") == \"true\"\n",
+    "df_train, df_valid, df_test = load_vrd_data(sample, is_test)\n",
     "\n",
     "print(\"Train Relationships: \", len(df_train))\n",
     "print(\"Dev Relationships: \", len(df_valid))\n",
@@ -250,7 +250,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 26/26 [00:00<00:00, 3159.37it/s]"
+      "100%|██████████| 26/26 [00:00<00:00, 3094.55it/s]"
      ]
     },
     {
@@ -267,7 +267,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 26/26 [00:00<00:00, 4457.83it/s]"
+      "100%|██████████| 26/26 [00:00<00:00, 4482.94it/s]"
      ]
     },
     {
@@ -596,7 +596,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Epoch 0::  50%|█████     | 1/2 [00:01<00:01,  1.32s/it, model/all/train/loss=1.25, model/all/train/lr=0.001]"
+      "Epoch 0::  50%|█████     | 1/2 [00:01<00:01,  1.30s/it, model/all/train/loss=1.25, model/all/train/lr=0.001]"
      ]
     },
     {
@@ -604,7 +604,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Epoch 0::  50%|█████     | 1/2 [00:02<00:01,  1.32s/it, model/all/train/loss=1.07, model/all/train/lr=0.001]"
+      "Epoch 0::  50%|█████     | 1/2 [00:02<00:01,  1.30s/it, model/all/train/loss=1.07, model/all/train/lr=0.001]"
      ]
     },
     {
@@ -612,7 +612,15 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Epoch 0:: 100%|██████████| 2/2 [00:02<00:00,  1.20s/it, model/all/train/loss=1.07, model/all/train/lr=0.001]"
+      "Epoch 0:: 100%|██████████| 2/2 [00:02<00:00,  1.19s/it, model/all/train/loss=1.07, model/all/train/lr=0.001]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Epoch 0:: 100%|██████████| 2/2 [00:02<00:00,  1.12s/it, model/all/train/loss=1.07, model/all/train/lr=0.001]"
      ]
     },
     {

--- a/visual_relation/visual_relation_tutorial.py
+++ b/visual_relation/visual_relation_tutorial.py
@@ -36,8 +36,8 @@ from utils import load_vrd_data
 
 # setting sample=False will take ~3 hours to run (downloads full VRD dataset)
 sample = True
-is_travis = os.environ.get("TRAVIS") == "true"
-df_train, df_valid, df_test = load_vrd_data(sample, is_travis)
+is_test = os.environ.get("TRAVIS") == "true" or os.environ.get("IS_TEST") == "true"
+df_train, df_valid, df_test = load_vrd_data(sample, is_test)
 
 print("Train Relationships: ", len(df_train))
 print("Dev Relationships: ", len(df_valid))


### PR DESCRIPTION
1. Use sample data even during tox test.
2. Remove notebook_metadata_filter to allow syncing using jupytext in-browser pairing instead of manually running sync command. 

**Test Plan**
tox. Ran recsys test locally to ensure it is fast, ran recsys sync to make sure it's slow, and tried testing after browser pairing.