### PR TITLE
Update download_data.sh

### DIFF
--- a/getting_started/download_data.sh
+++ b/getting_started/download_data.sh
@@ -22,7 +22,7 @@ done
 if [ "$RELOAD" = true ]; then
     if [ -d "data/" ]; then rm -Rf "data/"; fi
     mkdir -p data
-    wget $DATA_URL -O data.zip
+    curl $DATA_URL > data.zip
     mv data.zip data/
     cd data
     unzip data.zip


### PR DESCRIPTION
## Description of proposed changes
Changing wget for curl in download_data.sh

## Related issue(s)
I discovered a problem when running the getting_started.ipynb notebook, when loading df_train. If you are on a Mac without wget installed, the code in line 25 of the script getting_started/download_data.sh will fail.

Fixes # (issue)
exchange the statement in line 25 of the script getting_started/download_data.sh to curl $DATA_URL > data.zip

## Test plan
Run all cells of the notebook `getting_started.ipynb` on a Mac computer successfuly. 

## Checklist

Need help on these? Just ask!

* [x ] I have read the **CONTRIBUTING** document.
* [ x] I have verified that my changes are covered by continuous integration.
* [ x] All new and existing tests passed.
