### PR TITLE
fixed func parameter reference for patience; parameterized monitor

### DIFF
--- a/spam/utils.py
+++ b/spam/utils.py
@@ -85,9 +85,10 @@ def get_keras_lstm(num_buckets, embed_dim=16, rnn_state_size=64):
     return lstm_model
 
 
-def get_keras_early_stopping(patience=10):
+def get_keras_early_stopping(patience=10, monitor="val_acc"):
+    """Stops training if monitor value doesn't exceed the current max value after patience num of epochs"""
     return tf.keras.callbacks.EarlyStopping(
-        monitor="val_acc", patience=10, verbose=1, restore_best_weights=True
+        monitor=monitor, patience=patience, verbose=1, restore_best_weights=True
     )
 
 


### PR DESCRIPTION
## Description of proposed changes
- changed function invocation to use the parameterized "patience" instead of hard coded value
- parameterized monitor so that you can choose which monitor to use as your stopping criteria

Fixes #157

* [x ] I have read the **CONTRIBUTING** document.

I tested the run on spam tutorial #1, but my tox testing is failing with:
spam create: /app/snorkel-tutorials/.tox/spam
spam installdeps: -rrequirements.txt, -rspam/requirements.txt
ERROR: invocation failed (exit code -9), logfile: /app/snorkel-tutorials/.tox/spam/log/spam-1.log
=========================================================================================== log start ===========================================================================================
Collecting snorkel==0.9.0 (from -r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/42/12/9c5ac9e097574a0657026af7cd127fddbe8f0888dc4fccedb26a8c29e1b6/snorkel-0.9.0-py3-none-any.whl
Collecting black==19.3b0 (from -r requirements.txt (line 8))
  Using cached https://files.pythonhosted.org/packages/30/62/cf549544a5fe990bbaeca21e9c419501b2de7a701ab0afb377bc81676600/black-19.3b0-py36-none-any.whl
Collecting flake8==3.7.8 (from -r requirements.txt (line 9))
  Using cached https://files.pythonhosted.org/packages/26/de/3f815a99d86eb10464ea7bd6059c0172c7ca97d4bdcfca41051b388a653b/flake8-3.7.8-py2.py3-none-any.whl
Collecting jupyter==1.0.0 (from -r requirements.txt (line 10))
  Using cached https://files.pythonhosted.org/packages/83/df/0f5dd132200728a86190397e1ea87cd76244e42d39ec5e88efd25b2abd7e/jupyter-1.0.0-py2.py3-none-any.whl
Collecting jupytext==1.2.0 (from -r requirements.txt (line 11))
Collecting nbconvert==5.5.0 (from -r requirements.txt (line 12))
  Using cached https://files.pythonhosted.org/packages/35/e7/f46c9d65f149271e47fca6ab084ef5c6e4cb1870f4c5cce6690feac55231/nbconvert-5.5.0-py2.py3-none-any.whl
Collecting matplotlib==3.1.1 (from -r spam/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/57/4f/dd381ecf6c6ab9bcdaa8ea912e866dedc6e696756156d8ecc087e20817e2/matplotlib-3.1.1-cp36-cp36m-manylinux1_x86_64.whl
Collecting names==0.3.0 (from -r spam/requirements.txt (line 2))
Collecting nltk==3.4.5 (from -r spam/requirements.txt (line 3))
Collecting numpy<1.17.0,>=1.16.0 (from -r spam/requirements.txt (line 4))
  Using cached https://files.pythonhosted.org/packages/98/87/41283370f942f647422581eed16df4b653a744a3e9d5cfbb9aee0440f6eb/numpy-1.16.5-cp36-cp36m-manylinux1_x86_64.whl
Collecting pandas<0.25.0,>=0.24.0 (from -r spam/requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/19/74/e50234bc82c553fecdbd566d8650801e3fe2d6d8c8d940638e3d8a7c5522/pandas-0.24.2-cp36-cp36m-manylinux1_x86_64.whl
Collecting scikit-learn>=0.20.2 (from -r spam/requirements.txt (line 6))
  Using cached https://files.pythonhosted.org/packages/a0/c5/d2238762d780dde84a20b8c761f563fe882b88c5a5fb03c056547c442a19/scikit_learn-0.21.3-cp36-cp36m-manylinux1_x86_64.whl
Collecting spacy>=2.1.6 (from -r spam/requirements.txt (line 7))
  Using cached https://files.pythonhosted.org/packages/95/9c/afd55bb35cc03e4b3dadc41dd48bc26e0678b08d59f32411735c35bda550/spacy-2.1.8-cp36-cp36m-manylinux1_x86_64.whl
Collecting tensorflow==1.14.0 (from -r spam/requirements.txt (line 8))
  Using cached https://files.pythonhosted.org/packages/de/f0/96fb2e0412ae9692dbf400e5b04432885f677ad6241c088ccc5fe7724d69/tensorflow-1.14.0-cp36-cp36m-manylinux1_x86_64.whl
Collecting textblob==0.15.3 (from -r spam/requirements.txt (line 9))
  Using cached https://files.pythonhosted.org/packages/60/f0/1d9bfcc8ee6b83472ec571406bd0dd51c0e6330ff1a51b2d29861d389e85/textblob-0.15.3-py2.py3-none-any.whl
Collecting tqdm<5.0.0,>=4.29.0 (from snorkel==0.9.0->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/e1/c1/bc1dba38b48f4ae3c4428aea669c5e27bd5a7642a74c8348451e0bd8ff86/tqdm-4.36.1-py2.py3-none-any.whl
Collecting networkx<3.0,>=2.2 (from snorkel==0.9.0->-r requirements.txt (line 3))
Collecting scipy<2.0.0,>=1.2.0 (from snorkel==0.9.0->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/29/50/a552a5aff252ae915f522e44642bb49a7b7b31677f9580cfd11bcc869976/scipy-1.3.1-cp36-cp36m-manylinux1_x86_64.whl
Collecting tensorboardX<2.0,>=1.6 (from snorkel==0.9.0->-r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/c3/12/dcaf67e1312475b26db9e45e7bb6f32b540671a9ee120b3a72d9e09bc517/tensorboardX-1.8-py2.py3-none-any.whl
Collecting torch<1.2.0,>=1.1.0 (from snorkel==0.9.0->-r requirements.txt (line 3))

============================================================================================ log end ============================================================================================
ERROR: could not install deps [-rrequirements.txt, -rspam/requirements.txt]; v = InvocationError('/app/snorkel-tutorials/.tox/spam/bin/python -m pip install -rrequirements.txt -rspam/requirements.txt', -9)
____________________________________________________________________________________________ summary ____________________________________________________________________________________________
ERROR:   spam: could not install deps [-rrequirements.txt, -rspam/requirements.txt]; v = InvocationError('/app/snorkel-tutorials/.tox/spam/bin/python -m pip install -rrequirements.txt -rspam/requirements.txt', -9)

