### PR TITLE
Remove probabilistic in crowdsourcing tutorial

### DIFF
--- a/crowdsourcing/crowdsourcing_tutorial.ipynb
+++ b/crowdsourcing/crowdsourcing_tutorial.ipynb
@@ -419,7 +419,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 58%|█████▊    | 109/187 [00:00<00:00, 1085.25it/s]"
+      " 56%|█████▌    | 104/187 [00:00<00:00, 1031.43it/s]"
      ]
     },
     {
@@ -427,7 +427,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 187/187 [00:00<00:00, 1078.79it/s]"
+      "100%|██████████| 187/187 [00:00<00:00, 1031.16it/s]"
      ]
     },
     {
@@ -444,7 +444,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 50/50 [00:00<00:00, 1074.72it/s]"
+      "100%|██████████| 50/50 [00:00<00:00, 1021.63it/s]"
      ]
     },
     {
@@ -509,59 +509,59 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>worker_18914675</th>\n",
-       "      <td>85</td>\n",
+       "      <th>worker_17652569</th>\n",
+       "      <td>70</td>\n",
        "      <td>[]</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0.00</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_6371053</th>\n",
-       "      <td>9</td>\n",
+       "      <th>worker_16498372</th>\n",
+       "      <td>58</td>\n",
        "      <td>[0, 1]</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>4</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0.800000</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_6340330</th>\n",
-       "      <td>2</td>\n",
-       "      <td>[1]</td>\n",
+       "      <th>worker_18465660</th>\n",
+       "      <td>80</td>\n",
+       "      <td>[0, 1]</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>0.06</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>worker_12572470</th>\n",
+       "      <td>38</td>\n",
+       "      <td>[0, 1]</td>\n",
        "      <td>0.04</td>\n",
        "      <td>0.04</td>\n",
        "      <td>0.04</td>\n",
        "      <td>2</td>\n",
        "      <td>0</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>worker_6332651</th>\n",
-       "      <td>0</td>\n",
+       "      <th>worker_18975312</th>\n",
+       "      <td>88</td>\n",
        "      <td>[0, 1]</td>\n",
-       "      <td>0.06</td>\n",
-       "      <td>0.06</td>\n",
-       "      <td>0.06</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>0.02</td>\n",
        "      <td>2</td>\n",
-       "      <td>0.333333</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>worker_14400603</th>\n",
-       "      <td>43</td>\n",
-       "      <td>[0, 1]</td>\n",
-       "      <td>0.18</td>\n",
-       "      <td>0.18</td>\n",
-       "      <td>0.18</td>\n",
-       "      <td>8</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0.888889</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -569,18 +569,18 @@
       ],
       "text/plain": [
        "                  j Polarity  Coverage  Overlaps  Conflicts  Correct  \\\n",
-       "worker_18914675  85  []       0.00      0.00      0.00       0         \n",
-       "worker_6371053   9   [0, 1]   0.10      0.10      0.10       4         \n",
-       "worker_6340330   2   [1]      0.04      0.04      0.04       2         \n",
-       "worker_6332651   0   [0, 1]   0.06      0.06      0.06       1         \n",
-       "worker_14400603  43  [0, 1]   0.18      0.18      0.18       8         \n",
+       "worker_17652569  70  []       0.00      0.00      0.00       0         \n",
+       "worker_16498372  58  [0, 1]   0.06      0.06      0.04       3         \n",
+       "worker_18465660  80  [0, 1]   0.06      0.06      0.06       3         \n",
+       "worker_12572470  38  [0, 1]   0.04      0.04      0.04       2         \n",
+       "worker_18975312  88  [0, 1]   0.04      0.04      0.02       2         \n",
        "\n",
        "                 Incorrect  Emp. Acc.  \n",
-       "worker_18914675  0          0.000000   \n",
-       "worker_6371053   1          0.800000   \n",
-       "worker_6340330   0          1.000000   \n",
-       "worker_6332651   2          0.333333   \n",
-       "worker_14400603  1          0.888889   "
+       "worker_17652569  0          0.0        \n",
+       "worker_16498372  0          1.0        \n",
+       "worker_18465660  0          1.0        \n",
+       "worker_12572470  0          1.0        \n",
+       "worker_18975312  0          1.0        "
       ]
      },
      "execution_count": 8,
@@ -697,7 +697,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 19%|█▊        | 35/187 [00:00<00:00, 349.28it/s]"
+      " 18%|█▊        | 34/187 [00:00<00:00, 336.60it/s]"
      ]
     },
     {
@@ -705,7 +705,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 34%|███▎      | 63/187 [00:00<00:00, 324.19it/s]"
+      " 46%|████▌     | 86/187 [00:00<00:00, 376.05it/s]"
      ]
     },
     {
@@ -713,7 +713,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 63%|██████▎   | 117/187 [00:00<00:00, 367.63it/s]"
+      " 74%|███████▍  | 139/187 [00:00<00:00, 410.40it/s]"
      ]
     },
     {
@@ -721,15 +721,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 91%|█████████▏| 171/187 [00:00<00:00, 405.59it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "100%|██████████| 187/187 [00:00<00:00, 429.01it/s]"
+      "100%|██████████| 187/187 [00:00<00:00, 469.41it/s]"
      ]
     },
     {
@@ -746,7 +738,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 50/50 [00:00<00:00, 529.64it/s]"
+      "100%|██████████| 50/50 [00:00<00:00, 515.15it/s]"
      ]
     },
     {
@@ -980,7 +972,7 @@
     "at inference time.**\n",
     "In order to run inference on new incoming data points, we need to train a\n",
     "discriminative model over the tweets themselves.\n",
-    "Let's generate a set of probabilistic labels for that training set."
+    "Let's generate a set of labels for that training set."
    ]
   },
   {
@@ -1040,7 +1032,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Model on probabilistic labels\n",
+    "### Model on labels\n",
     "Now, we train a simple logistic regression model on the BERT features, using labels\n",
     "obtained from our LabelModel."
    ]
@@ -1109,7 +1101,7 @@
     "In this tutorial, we accomplished the following:\n",
     "* We demonstrated how to combine crowdsourced labels with other programmatic LFs to improve coverage.\n",
     "* We used the `LabelModel` to combine inputs from crowdworkers and other LFs to generate high quality probabilistic labels.\n",
-    "* We used our probabilistic labels to train a classifier for making predictions on new, unseen data points."
+    "* We used our labels to train a classifier for making predictions on new, unseen data points."
    ]
   }
  ],

--- a/crowdsourcing/crowdsourcing_tutorial.py
+++ b/crowdsourcing/crowdsourcing_tutorial.py
@@ -229,7 +229,7 @@ print(f"LabelModel Accuracy: {acc:.3f}")
 # at inference time.**
 # In order to run inference on new incoming data points, we need to train a
 # discriminative model over the tweets themselves.
-# Let's generate a set of probabilistic labels for that training set.
+# Let's generate a set of labels for that training set.
 
 # %%
 preds_train = label_model.predict(L_train)
@@ -261,7 +261,7 @@ X_train = np.array(list(df_train.tweet_text.apply(encode_text).values))
 X_test = np.array(list(df_test.tweet_text.apply(encode_text).values))
 
 # %% [markdown]
-# ### Model on probabilistic labels
+# ### Model on labels
 # Now, we train a simple logistic regression model on the BERT features, using labels
 # obtained from our LabelModel.
 
@@ -283,4 +283,4 @@ print(f"Accuracy of trained model: {sklearn_model.score(X_test, Y_test)}")
 # In this tutorial, we accomplished the following:
 # * We demonstrated how to combine crowdsourced labels with other programmatic LFs to improve coverage.
 # * We used the `LabelModel` to combine inputs from crowdworkers and other LFs to generate high quality probabilistic labels.
-# * We used our probabilistic labels to train a classifier for making predictions on new, unseen data points.
+# * We used our labels to train a classifier for making predictions on new, unseen data points.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 #### ESSENTIAL LIBRARIES
 
-snorkel==0.9.0
+snorkel==0.9.2
 
 
 #### DEV TOOLS


### PR DESCRIPTION
## Description of proposed changes
Remove some uses of the word `probabilistic` in crowdsourcing tutorial, since we are actually calling `LabelModel.predict`, which generates discrete (non-probabilistic) labels.
 
Fixes # (issue)
#166 

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have verified that my changes are covered by continuous integration.
* [ ] All new and existing tests passed.
