### PR TITLE
Speed up tox tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 #### ESSENTIAL LIBRARIES
 
-snorkel==0.9.2
+snorkel==0.9.3
 
 
 #### DEV TOOLS

--- a/visual_relation/download_sample_data.sh
+++ b/visual_relation/download_sample_data.sh
@@ -20,7 +20,10 @@ done
 
 ANNOTATIONS_URL="https://www.dropbox.com/s/bnfhm6kt9xumik8/vrd.zip"
 SAMPLE_IMAGES_URL="https://github.com/Prof-Lu-Cewu/Visual-Relationship-Detection.git"
-GLOVE_URL="http://nlp.stanford.edu/data/wordvecs/glove.6B.zip"
+
+# NOTE: We download a smaller version of the 6B glove embeddings file, where
+# originally GLOVE_URL="http://nlp.stanford.edu/data/wordvecs/glove.6B.zip"
+GLOVE_URL="https://www.dropbox.com/s/2yg2r8931qx12xp/glove.100d.zip"
 
 if [ "$RELOAD" = true ]; then
     if [ -d "data" ]; then rm -Rf "data"; fi
@@ -48,10 +51,10 @@ if [ "$RELOAD" = true ]; then
     cd glove
 
     wget $GLOVE_URL
-    unzip glove.6B.zip
+    unzip glove.100d.zip
 
     # Delete the zip files
-    rm  glove.6B.zip
+    rm  glove.100d.zip
     cd ../..
 fi
 


### PR DESCRIPTION
## Description of proposed changes
Speed up `tox` tests in master so they don't hit the 50 min timeout limit
* Bump snorkel version to 0.9.3 — this uses @brahmaneya's fantastic implementation of tiebreaking algorithm, which brings some speedups to the multi-class tutorials
* Download a subset of glove embeddings when `is_test` flag is true in `visual_relation` tutorial

## Test plan
* Existing tests pass

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have verified that my changes are covered by continuous integration.
* [x] All new and existing tests passed.
