### PR TITLE
Update model.py

### DIFF
--- a/visual_relation/model.py
+++ b/visual_relation/model.py
@@ -186,7 +186,7 @@ def get_op_sequence():
     concat_op = Operation(
         name="concat_op",
         module_name="feat_concat",
-        inputs=["obj_feat_op", "sub_feat_op", "union_feat_op", "word_emb_op"],
+        inputs=["obj_feat_op", "sub_feat_op", "union_feat_op"],
     )
 
     # define an operation to make a prediction over all concatenated features
@@ -198,7 +198,6 @@ def get_op_sequence():
         sub_feat_op,
         obj_feat_op,
         union_feat_op,
-        word_emb_op,
         concat_op,
         prediction_op,
     ]
@@ -216,17 +215,17 @@ def create_model(resnet_cnn):
 
     # initialize FC layer: maps 3 sets of image features to class logits
     WEMB_SIZE = 100
-    fc = nn.Linear(in_features * 3 + 2 * WEMB_SIZE, 3)
+    fc = nn.Linear(in_features * 3, 3)
     init_fc(fc)
 
     # define layers
+    # define layers
     module_pool = nn.ModuleDict(
-        {
-            "feat_extractor": feature_extractor,
-            "prediction_head": fc,
-            "feat_concat": FlatConcat(),
-            "word_emb": WordEmb(),
-        }
+       {
+          "feat_extractor": feature_extractor,
+          "prediction_head": fc,
+          "feat_concat": FlatConcat()
+       }
     )
 
     # define task flow through modules


### PR DESCRIPTION
Fixed the issue with trainer.fit(model, [dl_train]) due to the WordEmb operation.
Also checked that the micro_f1 score is not impacted by the removal of the use of word embedding.

## Description of proposed changes
When running trainer.fit(model, [dl_train]), the code was failing with an invalud value operation returned by
ValueError: Unsuccessful operation Operation(name=word_emb_op, module_name=word_emb, inputs=[('input', 'sub_category'), ('input', 'obj_category')]).

Was looking at whether the use of the Word Embedding here would be useful.
Tried removing the word embedding, and verify that it fixed the runtime issue.

Also checked that the micro_f1 score is not impacted by the removal of the use of word embedding.

## Related issue(s)

Fixes # (issue)
223

## Test plan
Re-run the notebook visual_relation_tutorial, and verified that trainer.fit () runs successfully, with no impact on the f1_micro score at n_epochs=1. Same value as the original tutorial. Changes have been tested locally

## Checklist

Need help on these? Just ask!

* [Y] I have read the **CONTRIBUTING** document.
* [N ] I have verified that my changes are covered by continuous integration.
Changes have been tested locally by re-running the visual relations notebook

* [N] All new and existing tests passed.
Changes have been tested locally by re-running the visual relations notebook
