### PR TITLE
R tinn/multitask small fix

### DIFF
--- a/multitask/multitask_tutorial.ipynb
+++ b/multitask/multitask_tutorial.ipynb
@@ -838,4 +838,3 @@
  "nbformat": 4,
  "nbformat_minor": 4
 }
-

--- a/multitask/multitask_tutorial.ipynb
+++ b/multitask/multitask_tutorial.ipynb
@@ -791,7 +791,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# assert len(model.tasks) == 3\n",
+    "# assert len(model.task_names) == 3\n",
     "# assert len(model.module_pool) == 4  # 1 shared module plus 3 separate task heads"
    ]
   },

--- a/multitask/multitask_tutorial.ipynb
+++ b/multitask/multitask_tutorial.ipynb
@@ -838,3 +838,4 @@
  "nbformat": 4,
  "nbformat_minor": 4
 }
+

--- a/multitask/multitask_tutorial.py
+++ b/multitask/multitask_tutorial.py
@@ -384,7 +384,7 @@ model.score(all_dataloaders)
 # The following assert statements should also pass if you uncomment and run it.
 
 # %%
-# assert len(model.tasks) == 3
+# assert len(model.task_names) == 3
 # assert len(model.module_pool) == 4  # 1 shared module plus 3 separate task heads
 
 # %% [markdown]


### PR DESCRIPTION
Thanks Snorkel team for these informative tutorials! I have a small fix for the multitask tutorial.

## Description of proposed changes

Update the testing for the tutorial to test for the MultitaskClassifier's 'task_names' attribute, instead of throwing an error for the non-existent 'tasks' attribute.

## Checklist

- I have read the **CONTRIBUTING** document.
- All new and existing tests passed.
